### PR TITLE
Add automatic import sorting and extend linting to test/scripts

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,9 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "printWidth": 100
+  "printWidth": 100,
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "importOrder": ["^node:", "<THIRD_PARTY_MODULES>", "^[./]"],
+  "importOrderSeparation": false,
+  "importOrderSortSpecifiers": true
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ['dist/', 'node_modules/', '*.config.*', 'test/', 'e2e/'],
+    ignores: ['dist/', 'node_modules/', '*.config.*'],
   },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/node": "^25.4.0",
         "@vitest/coverage-v8": "^4.0.18",
         "eslint": "^10.0.3",
@@ -34,6 +35,55 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -70,6 +120,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/types": {
@@ -1253,6 +1337,17 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2091,6 +2186,80 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-6.0.2.tgz",
+      "integrity": "sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/generator": "^7.28.0",
+        "@babel/parser": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.0",
+        "javascript-natural-sort": "^0.7.1",
+        "lodash-es": "^4.17.21",
+        "minimatch": "^9.0.0",
+        "parse-imports-exports": "^0.2.4"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x",
+        "prettier-plugin-ember-template-tag": ">= 2.0.0",
+        "prettier-plugin-svelte": "3.x",
+        "svelte": "4.x || 5.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "prettier-plugin-ember-template-tag": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -5048,6 +5217,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5064,6 +5240,19 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -5294,6 +5483,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
@@ -5791,6 +5987,16 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
@@ -5802,6 +6008,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -6117,6 +6330,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "prepare": "npm run build",
     "dev": "npx fastmcp dev src/index.ts",
     "inspect": "npx fastmcp inspect src/index.ts",
-    "lint": "eslint src/",
-    "lint:fix": "eslint src/ --fix",
+    "lint": "eslint src/ test/ scripts/",
+    "lint:fix": "eslint src/ test/ scripts/ --fix",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"scripts/**/*.ts\" \"*.config.*\" \"*.json\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"scripts/**/*.ts\" \"*.config.*\"",
     "typecheck": "tsc --noEmit",
@@ -68,6 +68,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/node": "^25.4.0",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^10.0.3",

--- a/scripts/verify-package.ts
+++ b/scripts/verify-package.ts
@@ -5,11 +5,10 @@
  *
  * Usage: npx tsx scripts/verify-package.ts
  */
-
 import { execSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 const rootDir = join(import.meta.dirname, '..');
 
@@ -33,7 +32,6 @@ function main(): void {
     run(`npm install "${tarball.replace(/\\/g, '/')}"`, tempDir);
 
     // Verify the binary exists
-    const binPath = join(tempDir, 'node_modules', '.bin', 'mcp-video-analyzer');
     console.log(`[verify] Checking binary exists...`);
 
     // Try to start the server (should not crash on import)

--- a/src/adapters/adapter.interface.test.ts
+++ b/src/adapters/adapter.interface.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { registerAdapter, getAdapter, clearAdapters } from './adapter.interface.js';
-import { LoomAdapter } from './loom.adapter.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearAdapters, getAdapter, registerAdapter } from './adapter.interface.js';
 import { DirectAdapter } from './direct.adapter.js';
+import { LoomAdapter } from './loom.adapter.js';
 
 beforeEach(() => {
   clearAdapters();

--- a/src/adapters/adapter.interface.ts
+++ b/src/adapters/adapter.interface.ts
@@ -1,11 +1,11 @@
-import type {
-  ITranscriptEntry,
-  IVideoMetadata,
-  IVideoComment,
-  IChapter,
-  IAdapterCapabilities,
-} from '../types.js';
 import { UserError } from 'fastmcp';
+import type {
+  IAdapterCapabilities,
+  IChapter,
+  ITranscriptEntry,
+  IVideoComment,
+  IVideoMetadata,
+} from '../types.js';
 
 export interface IVideoAdapter {
   readonly name: string;

--- a/src/adapters/direct.adapter.test.ts
+++ b/src/adapters/direct.adapter.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 import { DirectAdapter } from './direct.adapter.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
 
 describe('DirectAdapter', () => {
   const adapter = new DirectAdapter();

--- a/src/adapters/direct.adapter.ts
+++ b/src/adapters/direct.adapter.ts
@@ -1,16 +1,16 @@
 import { createWriteStream } from 'node:fs';
 import { join } from 'node:path';
-import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import type {
-  ITranscriptEntry,
-  IVideoMetadata,
-  IVideoComment,
-  IChapter,
   IAdapterCapabilities,
+  IChapter,
+  ITranscriptEntry,
+  IVideoComment,
+  IVideoMetadata,
 } from '../types.js';
-import type { IVideoAdapter } from './adapter.interface.js';
 import { detectPlatform } from '../utils/url-detector.js';
+import type { IVideoAdapter } from './adapter.interface.js';
 
 function getFilenameFromUrl(url: string): string {
   try {

--- a/src/adapters/loom.adapter.test.ts
+++ b/src/adapters/loom.adapter.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FIXTURES_DIR } from '../../test/helpers/index.js';
+import { LoomAdapter } from './loom.adapter.js';
 
 // Mock child_process so findYtDlp resolves instantly (no real exec calls)
 vi.mock('node:child_process', () => ({
@@ -12,9 +14,6 @@ vi.mock('node:child_process', () => ({
     }
   },
 }));
-
-import { LoomAdapter } from './loom.adapter.js';
-import { FIXTURES_DIR } from '../../test/helpers/index.js';
 
 const metadataFixture = JSON.parse(
   readFileSync(join(FIXTURES_DIR, 'loom-graphql-metadata.json'), 'utf-8'),

--- a/src/adapters/loom.adapter.ts
+++ b/src/adapters/loom.adapter.ts
@@ -1,19 +1,19 @@
 import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
+import { createWriteStream, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { existsSync, createWriteStream } from 'node:fs';
-import { pipeline } from 'node:stream/promises';
 import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { promisify } from 'node:util';
 import type {
-  ITranscriptEntry,
-  IVideoMetadata,
-  IVideoComment,
-  IChapter,
   IAdapterCapabilities,
+  IChapter,
+  ITranscriptEntry,
+  IVideoComment,
+  IVideoMetadata,
 } from '../types.js';
-import type { IVideoAdapter } from './adapter.interface.js';
 import { detectPlatform, extractLoomId } from '../utils/url-detector.js';
 import { parseVtt } from '../utils/vtt-parser.js';
+import type { IVideoAdapter } from './adapter.interface.js';
 
 const execFile = promisify(execFileCb);
 

--- a/src/config/detail-levels.test.ts
+++ b/src/config/detail-levels.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { getDetailConfig, DETAIL_CONFIGS } from './detail-levels.js';
+import { describe, expect, it } from 'vitest';
+import { DETAIL_CONFIGS, getDetailConfig } from './detail-levels.js';
 import type { DetailLevel } from './detail-levels.js';
 
 describe('detail-levels', () => {

--- a/src/processors/annotated-timeline.test.ts
+++ b/src/processors/annotated-timeline.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import type { IFrameResult, ITranscriptEntry } from '../types.js';
 import { buildAnnotatedTimeline, parseTimeToSeconds } from './annotated-timeline.js';
-import type { ITranscriptEntry, IFrameResult } from '../types.js';
 import type { IOcrResult } from './frame-ocr.js';
 
 describe('annotated-timeline', () => {

--- a/src/processors/annotated-timeline.ts
+++ b/src/processors/annotated-timeline.ts
@@ -1,4 +1,4 @@
-import type { ITranscriptEntry, IFrameResult } from '../types.js';
+import type { IFrameResult, ITranscriptEntry } from '../types.js';
 import type { IOcrResult } from './frame-ocr.js';
 
 interface ITimelineEntry {

--- a/src/processors/audio-transcriber.test.ts
+++ b/src/processors/audio-transcriber.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { join } from 'node:path';
-import { extractAudioTrack, transcribeAudio } from './audio-transcriber.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FIXTURES_DIR } from '../../test/helpers/index.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
+import { extractAudioTrack, transcribeAudio } from './audio-transcriber.js';
 
 describe('extractAudioTrack', () => {
   it('throws for video without audio stream (tiny.mp4 has no audio)', async () => {

--- a/src/processors/audio-transcriber.ts
+++ b/src/processors/audio-transcriber.ts
@@ -1,7 +1,7 @@
 import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
-import { join } from 'node:path';
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 import type { ITranscriptEntry } from '../types.js';
 import { formatTimestamp } from './frame-extractor.js';
 

--- a/src/processors/browser-frame-extractor.test.ts
+++ b/src/processors/browser-frame-extractor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { generateTimestamps } from './browser-frame-extractor.js';
 
 describe('browser-frame-extractor', () => {

--- a/src/processors/frame-dedup.test.ts
+++ b/src/processors/frame-dedup.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { join } from 'node:path';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import sharp from 'sharp';
-import {
-  computeDHash,
-  hammingDistance,
-  deduplicateFrames,
-  isBlackFrame,
-  filterBlackFrames,
-} from './frame-dedup.js';
+import { describe, expect, it } from 'vitest';
 import { createTestImage } from '../../test/helpers/index.js';
 import type { IFrameResult } from '../types.js';
+import {
+  computeDHash,
+  deduplicateFrames,
+  filterBlackFrames,
+  hammingDistance,
+  isBlackFrame,
+} from './frame-dedup.js';
 
 describe('frame-dedup', () => {
   describe('computeDHash', () => {

--- a/src/processors/frame-extractor.test.ts
+++ b/src/processors/frame-extractor.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect } from 'vitest';
 import { existsSync } from 'node:fs';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FIXTURES_DIR } from '../../test/helpers/index.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 import {
-  parseTimestamp,
+  extractDenseFrames,
+  extractFrameAt,
   formatTimestamp,
   parseSceneTimestamps,
+  parseTimestamp,
   probeVideoDuration,
-  extractFrameAt,
-  extractDenseFrames,
 } from './frame-extractor.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
-import { FIXTURES_DIR } from '../../test/helpers/index.js';
 
 describe('parseTimestamp', () => {
   it('parses "1:23" to 83 seconds', () => {

--- a/src/processors/frame-extractor.ts
+++ b/src/processors/frame-extractor.ts
@@ -1,8 +1,8 @@
 import { execFile as execFileCb } from 'node:child_process';
-import { promisify } from 'node:util';
-import { join } from 'node:path';
 import { readdir } from 'node:fs/promises';
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 import type { IFrameResult } from '../types.js';
 
 const execFile = promisify(execFileCb);

--- a/src/processors/image-optimizer.test.ts
+++ b/src/processors/image-optimizer.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { statSync, existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import sharp from 'sharp';
-import { optimizeFrame, optimizeFrames } from './image-optimizer.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
+import { describe, expect, it } from 'vitest';
 import { createTestImage } from '../../test/helpers/index.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
+import { optimizeFrame, optimizeFrames } from './image-optimizer.js';
 
 describe('optimizeFrame', () => {
   it('resizes large image to max 800px width', async () => {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { clearAdapters } from './adapters/adapter.interface.js';
 import { createServer } from './server.js';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,14 @@
 import { FastMCP } from 'fastmcp';
 import { registerAdapter } from './adapters/adapter.interface.js';
-import { LoomAdapter } from './adapters/loom.adapter.js';
 import { DirectAdapter } from './adapters/direct.adapter.js';
+import { LoomAdapter } from './adapters/loom.adapter.js';
+import { registerAnalyzeMoment } from './tools/analyze-moment.js';
 import { registerAnalyzeVideo } from './tools/analyze-video.js';
 import { registerGetFrameAt } from './tools/get-frame-at.js';
 import { registerGetFrameBurst } from './tools/get-frame-burst.js';
-import { registerGetTranscript } from './tools/get-transcript.js';
-import { registerGetMetadata } from './tools/get-metadata.js';
 import { registerGetFrames } from './tools/get-frames.js';
-import { registerAnalyzeMoment } from './tools/analyze-moment.js';
+import { registerGetMetadata } from './tools/get-metadata.js';
+import { registerGetTranscript } from './tools/get-transcript.js';
 
 export function createServer(): FastMCP {
   const server = new FastMCP({

--- a/src/tools/analyze-moment.test.ts
+++ b/src/tools/analyze-moment.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerAnalyzeMoment } from './analyze-moment.js';
-import { registerAdapter, clearAdapters } from '../adapters/adapter.interface.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../adapters/adapter.interface.js';
 import type { IVideoAdapter } from '../adapters/adapter.interface.js';
+import { registerAnalyzeMoment } from './analyze-moment.js';
 
 function createMockAdapter(overrides: Partial<IVideoAdapter> = {}): IVideoAdapter {
   return {

--- a/src/tools/analyze-moment.ts
+++ b/src/tools/analyze-moment.ts
@@ -1,11 +1,11 @@
 import type { FastMCP } from 'fastmcp';
-import { imageContent, UserError } from 'fastmcp';
+import { UserError, imageContent } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
-import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
-import { deduplicateFrames } from '../processors/frame-dedup.js';
-import { extractTextFromFrames } from '../processors/frame-ocr.js';
 import { buildAnnotatedTimeline } from '../processors/annotated-timeline.js';
+import { deduplicateFrames } from '../processors/frame-dedup.js';
+import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
+import { extractTextFromFrames } from '../processors/frame-ocr.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createTempDir } from '../utils/temp-files.js';
 

--- a/src/tools/analyze-video.test.ts
+++ b/src/tools/analyze-video.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerAnalyzeVideo } from './analyze-video.js';
-import { registerAdapter, clearAdapters } from '../adapters/adapter.interface.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../adapters/adapter.interface.js';
 import type { IVideoAdapter } from '../adapters/adapter.interface.js';
 import type { IAdapterCapabilities } from '../types.js';
+import { registerAnalyzeVideo } from './analyze-video.js';
 
 function createMockAdapter(overrides: Partial<IVideoAdapter> = {}): IVideoAdapter {
   const capabilities: IAdapterCapabilities = {

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -1,25 +1,25 @@
 import type { FastMCP } from 'fastmcp';
-import { imageContent, UserError } from 'fastmcp';
+import { UserError, imageContent } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
-import {
-  extractSceneFrames,
-  extractDenseFrames,
-  probeVideoDuration,
-  formatTimestamp,
-} from '../processors/frame-extractor.js';
+import { getDetailConfig } from '../config/detail-levels.js';
+import { buildAnnotatedTimeline } from '../processors/annotated-timeline.js';
+import { extractAudioTrack, transcribeAudio } from '../processors/audio-transcriber.js';
 import { extractBrowserFrames, generateTimestamps } from '../processors/browser-frame-extractor.js';
 import { deduplicateFrames, filterBlackFrames } from '../processors/frame-dedup.js';
+import {
+  extractDenseFrames,
+  extractSceneFrames,
+  formatTimestamp,
+  probeVideoDuration,
+} from '../processors/frame-extractor.js';
 import { extractTextFromFrames } from '../processors/frame-ocr.js';
-import { buildAnnotatedTimeline } from '../processors/annotated-timeline.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
-import { extractAudioTrack, transcribeAudio } from '../processors/audio-transcriber.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
+import type { IAnalysisResult } from '../types.js';
 import { AnalysisCache, cacheKey } from '../utils/cache.js';
-import { getDetailConfig } from '../config/detail-levels.js';
 import { filterAnalysisResult } from '../utils/field-filter.js';
 import type { AnalysisField } from '../utils/field-filter.js';
-import type { IAnalysisResult } from '../types.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 
 const cache = new AnalysisCache();
 

--- a/src/tools/get-frame-at.test.ts
+++ b/src/tools/get-frame-at.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerGetFrameAt } from './get-frame-at.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearAdapters } from '../adapters/adapter.interface.js';
+import { registerGetFrameAt } from './get-frame-at.js';
 
 describe('get_frame_at tool', () => {
   let server: FastMCP;

--- a/src/tools/get-frame-at.ts
+++ b/src/tools/get-frame-at.ts
@@ -1,9 +1,9 @@
 import type { FastMCP } from 'fastmcp';
-import { imageContent, UserError } from 'fastmcp';
+import { UserError, imageContent } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
-import { extractFrameAt, parseTimestamp } from '../processors/frame-extractor.js';
 import { extractBrowserFrames } from '../processors/browser-frame-extractor.js';
+import { extractFrameAt, parseTimestamp } from '../processors/frame-extractor.js';
 import { optimizeFrame } from '../processors/image-optimizer.js';
 import { createTempDir } from '../utils/temp-files.js';
 import { getTempFilePath } from '../utils/temp-files.js';

--- a/src/tools/get-frame-burst.test.ts
+++ b/src/tools/get-frame-burst.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerGetFrameBurst } from './get-frame-burst.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { clearAdapters } from '../adapters/adapter.interface.js';
+import { registerGetFrameBurst } from './get-frame-burst.js';
 
 describe('get_frame_burst tool', () => {
   let server: FastMCP;

--- a/src/tools/get-frame-burst.ts
+++ b/src/tools/get-frame-burst.ts
@@ -1,9 +1,9 @@
 import type { FastMCP } from 'fastmcp';
-import { imageContent, UserError } from 'fastmcp';
+import { UserError, imageContent } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
-import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
 import { extractBrowserFrames } from '../processors/browser-frame-extractor.js';
+import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createTempDir } from '../utils/temp-files.js';
 

--- a/src/tools/get-frames.test.ts
+++ b/src/tools/get-frames.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerGetFrames } from './get-frames.js';
-import { registerAdapter, clearAdapters } from '../adapters/adapter.interface.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../adapters/adapter.interface.js';
 import type { IVideoAdapter } from '../adapters/adapter.interface.js';
+import { registerGetFrames } from './get-frames.js';
 
 function createMockAdapter(overrides: Partial<IVideoAdapter> = {}): IVideoAdapter {
   return {

--- a/src/tools/get-frames.ts
+++ b/src/tools/get-frames.ts
@@ -1,15 +1,15 @@
 import type { FastMCP } from 'fastmcp';
-import { imageContent, UserError } from 'fastmcp';
+import { UserError, imageContent } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
-import {
-  extractSceneFrames,
-  extractDenseFrames,
-  probeVideoDuration,
-  formatTimestamp,
-} from '../processors/frame-extractor.js';
 import { extractBrowserFrames, generateTimestamps } from '../processors/browser-frame-extractor.js';
 import { deduplicateFrames, filterBlackFrames } from '../processors/frame-dedup.js';
+import {
+  extractDenseFrames,
+  extractSceneFrames,
+  formatTimestamp,
+  probeVideoDuration,
+} from '../processors/frame-extractor.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createTempDir } from '../utils/temp-files.js';
 

--- a/src/tools/get-metadata.test.ts
+++ b/src/tools/get-metadata.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerGetMetadata } from './get-metadata.js';
-import { registerAdapter, clearAdapters } from '../adapters/adapter.interface.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../adapters/adapter.interface.js';
 import type { IVideoAdapter } from '../adapters/adapter.interface.js';
+import { registerGetMetadata } from './get-metadata.js';
 
 function createMockAdapter(overrides: Partial<IVideoAdapter> = {}): IVideoAdapter {
   return {

--- a/src/tools/get-transcript.test.ts
+++ b/src/tools/get-transcript.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FastMCP } from 'fastmcp';
-import { registerGetTranscript } from './get-transcript.js';
-import { registerAdapter, clearAdapters } from '../adapters/adapter.interface.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../adapters/adapter.interface.js';
 import type { IVideoAdapter } from '../adapters/adapter.interface.js';
+import { registerGetTranscript } from './get-transcript.js';
 
 function createMockAdapter(overrides: Partial<IVideoAdapter> = {}): IVideoAdapter {
   return {

--- a/src/tools/get-transcript.ts
+++ b/src/tools/get-transcript.ts
@@ -3,7 +3,7 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
 import { extractAudioTrack, transcribeAudio } from '../processors/audio-transcriber.js';
-import { createTempDir, cleanupTempDir } from '../utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 
 const GetTranscriptSchema = z.object({
   url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AnalysisCache, cacheKey } from './cache.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IAnalysisResult } from '../types.js';
+import { AnalysisCache, cacheKey } from './cache.js';
 
 function createMockResult(title = 'Test Video'): IAnalysisResult {
   return {

--- a/src/utils/field-filter.test.ts
+++ b/src/utils/field-filter.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { filterAnalysisResult } from './field-filter.js';
+import { describe, expect, it } from 'vitest';
 import type { IAnalysisResult } from '../types.js';
+import { filterAnalysisResult } from './field-filter.js';
 
 function createFullResult(): IAnalysisResult {
   return {

--- a/src/utils/temp-files.test.ts
+++ b/src/utils/temp-files.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createTempDir, cleanupTempDir, getTempFilePath } from './temp-files.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanupTempDir, createTempDir, getTempFilePath } from './temp-files.js';
 
 const dirsToClean: string[] = [];
 

--- a/src/utils/url-detector.test.ts
+++ b/src/utils/url-detector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { detectPlatform, extractLoomId } from './url-detector.js';
 
 describe('detectPlatform', () => {

--- a/src/utils/vtt-parser.test.ts
+++ b/src/utils/vtt-parser.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { parseVtt } from './vtt-parser.js';
+import { describe, expect, it } from 'vitest';
 import { FIXTURES_DIR } from '../../test/helpers/index.js';
+import { parseVtt } from './vtt-parser.js';
 
 describe('parseVtt', () => {
   it('parses the sample.vtt fixture correctly', () => {

--- a/test/e2e/analyze-direct.e2e.test.ts
+++ b/test/e2e/analyze-direct.e2e.test.ts
@@ -1,16 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { extractFrameAt, probeVideoDuration } from '../../src/processors/frame-extractor.js';
 import { optimizeFrame } from '../../src/processors/image-optimizer.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
-
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: Direct video analysis', () => {
@@ -37,6 +36,7 @@ describe('E2E: Direct video analysis', () => {
     const videoPath = await adapter.downloadVideo(TEST_VIDEO_URL, tempDir);
 
     expect(videoPath).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(existsSync(videoPath!)).toBe(true);
   });
 

--- a/test/e2e/analyze-loom.e2e.test.ts
+++ b/test/e2e/analyze-loom.e2e.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
 import { TEST_LOOM_URL } from './fixtures.js';

--- a/test/e2e/analyze-moment.e2e.test.ts
+++ b/test/e2e/analyze-moment.e2e.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
+import { deduplicateFrames } from '../../src/processors/frame-dedup.js';
 import { extractFrameBurst, parseTimestamp } from '../../src/processors/frame-extractor.js';
 import { optimizeFrames } from '../../src/processors/image-optimizer.js';
-import { deduplicateFrames } from '../../src/processors/frame-dedup.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: analyze_moment with direct video', () => {

--- a/test/e2e/cache.e2e.test.ts
+++ b/test/e2e/cache.e2e.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import type { IAnalysisResult } from '../../src/types.js';
 import { AnalysisCache, cacheKey } from '../../src/utils/cache.js';
 import { filterAnalysisResult } from '../../src/utils/field-filter.js';
-import type { IAnalysisResult } from '../../src/types.js';
 
 function createResult(title = 'Test'): IAnalysisResult {
   return {
@@ -71,6 +71,7 @@ describe('E2E: Cache integration', () => {
     result.warnings.push('test warning');
 
     cache.set(key, result);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const cached = cache.get(key)!;
 
     const filtered = filterAnalysisResult(cached, ['metadata']);

--- a/test/e2e/detail-levels.e2e.test.ts
+++ b/test/e2e/detail-levels.e2e.test.ts
@@ -1,20 +1,19 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
+import { getDetailConfig } from '../../src/config/detail-levels.js';
 import {
-  extractSceneFrames,
   extractDenseFrames,
+  extractSceneFrames,
   probeVideoDuration,
 } from '../../src/processors/frame-extractor.js';
-import { getDetailConfig } from '../../src/config/detail-levels.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: Detail levels with direct video', () => {

--- a/test/e2e/get-frame-at.e2e.test.ts
+++ b/test/e2e/get-frame-at.e2e.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { extractFrameAt } from '../../src/processors/frame-extractor.js';
 import { optimizeFrame } from '../../src/processors/image-optimizer.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: get_frame_at', () => {

--- a/test/e2e/get-frame-burst.e2e.test.ts
+++ b/test/e2e/get-frame-burst.e2e.test.ts
@@ -1,14 +1,14 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { extractFrameBurst } from '../../src/processors/frame-extractor.js';
 import { optimizeFrames } from '../../src/processors/image-optimizer.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: get_frame_burst', () => {

--- a/test/e2e/get-frames.e2e.test.ts
+++ b/test/e2e/get-frames.e2e.test.ts
@@ -1,19 +1,19 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { existsSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
+import { deduplicateFrames } from '../../src/processors/frame-dedup.js';
 import {
-  extractSceneFrames,
   extractDenseFrames,
+  extractSceneFrames,
   probeVideoDuration,
 } from '../../src/processors/frame-extractor.js';
-import { deduplicateFrames } from '../../src/processors/frame-dedup.js';
-import { createTempDir, cleanupTempDir } from '../../src/utils/temp-files.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { TEST_DIRECT_VIDEO_URL as TEST_VIDEO_URL } from './fixtures.js';
 
 describe('E2E: get_frames with direct video', () => {
@@ -37,6 +37,7 @@ describe('E2E: get_frames with direct video', () => {
 
   it('downloads video for frame extraction', () => {
     expect(videoPath).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     expect(existsSync(videoPath!)).toBe(true);
   });
 

--- a/test/e2e/get-metadata.e2e.test.ts
+++ b/test/e2e/get-metadata.e2e.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
-import { TEST_LOOM_URL, TEST_DIRECT_VIDEO_URL } from './fixtures.js';
+import { TEST_DIRECT_VIDEO_URL, TEST_LOOM_URL } from './fixtures.js';
 
 describe('E2E: get_metadata with direct video', () => {
   beforeAll(() => {

--- a/test/e2e/get-transcript.e2e.test.ts
+++ b/test/e2e/get-transcript.e2e.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { DirectAdapter } from '../../src/adapters/direct.adapter.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
-import { TEST_LOOM_URL, TEST_DIRECT_VIDEO_URL } from './fixtures.js';
+import { TEST_DIRECT_VIDEO_URL, TEST_LOOM_URL } from './fixtures.js';
 
 describe('E2E: get_transcript with direct video', () => {
   beforeAll(() => {

--- a/test/e2e/partial-results.e2e.test.ts
+++ b/test/e2e/partial-results.e2e.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import {
-  registerAdapter,
   clearAdapters,
   getAdapter,
+  registerAdapter,
 } from '../../src/adapters/adapter.interface.js';
 import { LoomAdapter } from '../../src/adapters/loom.adapter.js';
 import { TEST_LOOM_URL } from './fixtures.js';

--- a/test/smoke/server-startup.test.ts
+++ b/test/smoke/server-startup.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { spawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
 
 const TIMEOUT_MS = 15000;
 const testDir = fileURLToPath(new URL('.', import.meta.url));
@@ -28,10 +28,12 @@ describe('MCP server smoke test', () => {
       let stdout = '';
       let stderr = '';
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       proc.stdout!.on('data', (chunk: Buffer) => {
         stdout += chunk.toString();
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       proc.stderr!.on('data', (chunk: Buffer) => {
         stderr += chunk.toString();
       });
@@ -54,6 +56,7 @@ describe('MCP server smoke test', () => {
         },
       });
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       proc.stdin!.write(initRequest + '\n');
 
       // Wait for response
@@ -77,6 +80,7 @@ describe('MCP server smoke test', () => {
       const jsonMatch = response.match(/\{[^]*"result"[^]*\}/);
       expect(jsonMatch, 'No JSON-RPC result found in output').not.toBeNull();
 
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const parsed = JSON.parse(jsonMatch![0]);
       expect(parsed.result?.serverInfo?.name).toBe('mcp-video-analyzer');
       expect(parsed.result?.capabilities).toBeDefined();


### PR DESCRIPTION
### Description

Adds Python-like import ordering and extends code quality tooling to cover the full codebase:

- **Import sorting** via `@trivago/prettier-plugin-sort-imports` — automatically orders imports: `node:` builtins → third-party packages → relative imports. Runs as part of `npm run format`.
- **Extended ESLint coverage** — `npm run lint` now covers `test/` and `scripts/` in addition to `src/`.
- **9 lint errors fixed** in test/script files (unused vars, non-null assertions).

### How Has This Been Tested?

- `npm run check` passes (format, lint, typecheck, knip, 193 unit tests)
- `npm run test:smoke` passes

### Checklist

- [x] I have tested and built the changes locally and they work as expected.
- [x] I have commented my code, especially in hard-to-understand areas, and added or updated relevant documentation.
- [x] I have ran the coding style library (e.g., ESLint, Prettier) on this branch.
- [x] My changes generate no new warnings

### Screenshots (if applicable)

N/A

### Additional Context

Import order: `node:*` → third-party (`vitest`, `sharp`, `fastmcp`, etc.) → relative (`../`, `./`). This matches the Python convention of stdlib → third-party → local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)