### PR TITLE
Fix OCR dropping accented characters (multilang support)

### DIFF
--- a/src/processors/frame-ocr.ts
+++ b/src/processors/frame-ocr.ts
@@ -12,11 +12,14 @@ export interface IOcrResult {
  *
  * Only includes results with meaningful text (confidence > 50%, text length > 3).
  */
-export async function extractTextFromFrames(frames: IFrameResult[]): Promise<IOcrResult[]> {
+export async function extractTextFromFrames(
+  frames: IFrameResult[],
+  language = 'eng+por',
+): Promise<IOcrResult[]> {
   const Tesseract = await loadTesseract();
   if (!Tesseract) return [];
 
-  const worker = await Tesseract.createWorker('eng');
+  const worker = await Tesseract.createWorker(language);
 
   try {
     const results: IOcrResult[] = [];

--- a/src/tools/analyze-moment.ts
+++ b/src/tools/analyze-moment.ts
@@ -20,6 +20,12 @@ const AnalyzeMomentSchema = z.object({
     .default(10)
     .optional()
     .describe('Number of frames to extract in the range (default: 10)'),
+  ocrLanguage: z
+    .string()
+    .optional()
+    .describe(
+      'Tesseract OCR language codes (default: "eng+por"). Use "+" to combine: "eng+spa", "eng+fra+deu".',
+    ),
 });
 
 export function registerAnalyzeMoment(server: FastMCP): void {
@@ -50,6 +56,7 @@ Requires video download capability for frame extraction.`,
     execute: async (args, { reportProgress }) => {
       const { url, from, to } = args;
       const count = args.count ?? 10;
+      const ocrLanguage = args.ocrLanguage ?? 'eng+por';
 
       // Validate timestamps
       const fromSeconds = parseTimestamp(from);
@@ -131,7 +138,7 @@ Requires video download capability for frame extraction.`,
       await reportProgress({ progress: 75, total: 100 });
 
       // OCR
-      const ocrResults = await extractTextFromFrames(frames).catch((e: unknown) => {
+      const ocrResults = await extractTextFromFrames(frames, ocrLanguage).catch((e: unknown) => {
         warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
         return [];
       });

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -79,6 +79,12 @@ const AnalyzeOptionsSchema = z
       .default(false)
       .optional()
       .describe('Bypass cache and re-analyze the video'),
+    ocrLanguage: z
+      .string()
+      .optional()
+      .describe(
+        'Tesseract OCR language codes (default: "eng+por"). Use "+" to combine: "eng+spa", "eng+fra+deu". See Tesseract docs for codes.',
+      ),
   })
   .optional();
 
@@ -123,6 +129,7 @@ Use options.forceRefresh to bypass the cache.`,
       const forceRefresh = options?.forceRefresh ?? false;
       const fields = options?.fields as AnalysisField[] | undefined;
       const threshold = options?.threshold ?? 0.1;
+      const ocrLanguage = options?.ocrLanguage ?? 'eng+por';
 
       // Resolve detail config
       const config = getDetailConfig(detail);
@@ -341,10 +348,12 @@ Use options.forceRefresh to bypass the cache.`,
 
             // OCR: extract text visible on screen
             if (config.includeOcr) {
-              result.ocrResults = await extractTextFromFrames(result.frames).catch((e: unknown) => {
-                warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
-                return [];
-              });
+              result.ocrResults = await extractTextFromFrames(result.frames, ocrLanguage).catch(
+                (e: unknown) => {
+                  warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
+                  return [];
+                },
+              );
             }
 
             await reportProgress({ progress: 95, total: 100 });


### PR DESCRIPTION
## Summary
- Default OCR language changed from `eng` to `eng+por` so Portuguese characters (é, ã, ç, ô, etc.) are recognized correctly
- Added `ocrLanguage` parameter to `analyze_video` and `analyze_moment` tools for user customization (e.g., `eng+spa`, `eng+fra+deu`)
- No breaking changes — existing calls work as before, just with better accent support

## Problem
OCR was replacing accented characters with `?`:
- "Formas Geométricas" → "Formas Geom?tricas"
- "o quadrado não consigo" → "o quadrado n?o consigo"

Root cause: Tesseract worker was hardcoded to `'eng'` only.

## Test plan
- [x] All 193 unit tests pass
- [x] `npm run check` passes (format, lint, typecheck, knip, tests)
- [ ] Manual test with Portuguese Loom video

🤖 Generated with [Claude Code](https://claude.com/claude-code)