### PR TITLE
Add streaming progress notifications to all tools

### DIFF
--- a/src/processors/frame-ocr.ts
+++ b/src/processors/frame-ocr.ts
@@ -15,6 +15,7 @@ export interface IOcrResult {
 export async function extractTextFromFrames(
   frames: IFrameResult[],
   language = 'eng+por',
+  onProgress?: (completed: number, total: number) => void,
 ): Promise<IOcrResult[]> {
   const Tesseract = await loadTesseract();
   if (!Tesseract) return [];
@@ -24,7 +25,8 @@ export async function extractTextFromFrames(
   try {
     const results: IOcrResult[] = [];
 
-    for (const frame of frames) {
+    for (let i = 0; i < frames.length; i++) {
+      const frame = frames[i];
       try {
         const {
           data: { text, confidence },
@@ -41,6 +43,7 @@ export async function extractTextFromFrames(
       } catch {
         // Skip frames that fail OCR
       }
+      onProgress?.(i + 1, frames.length);
     }
 
     return results;

--- a/src/tools/analyze-moment.ts
+++ b/src/tools/analyze-moment.ts
@@ -7,6 +7,7 @@ import { deduplicateFrames } from '../processors/frame-dedup.js';
 import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
 import { extractTextFromFrames } from '../processors/frame-ocr.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
+import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
 
 const AnalyzeMomentSchema = z.object({
@@ -54,6 +55,7 @@ Requires video download capability for frame extraction.`,
       openWorldHint: true,
     },
     execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url, from, to } = args;
       const count = args.count ?? 10;
       const ocrLanguage = args.ocrLanguage ?? 'eng+por';
@@ -79,7 +81,7 @@ Requires video download capability for frame extraction.`,
       const warnings: string[] = [];
       const tempDir = await createTempDir();
 
-      await reportProgress({ progress: 0, total: 100 });
+      await progress(0, `Starting moment analysis (${from} → ${to})...`);
 
       // Fetch transcript and filter to time range
       const fullTranscript = await adapter.getTranscript(url).catch((e: unknown) => {
@@ -92,7 +94,7 @@ Requires video download capability for frame extraction.`,
         return entrySeconds !== null && entrySeconds >= fromSeconds && entrySeconds <= toSeconds;
       });
 
-      await reportProgress({ progress: 20, total: 100 });
+      await progress(15, 'Transcript filtered to time range');
 
       // Download video and extract burst frames
       if (!adapter.capabilities.videoDownload) {
@@ -106,11 +108,11 @@ Requires video download capability for frame extraction.`,
         throw new UserError('Failed to download video for moment analysis.');
       }
 
-      await reportProgress({ progress: 40, total: 100 });
+      await progress(35, 'Video downloaded, extracting burst frames...');
 
       const rawFrames = await extractFrameBurst(videoPath, tempDir, from, to, count);
 
-      await reportProgress({ progress: 60, total: 100 });
+      await progress(55, `Extracted ${rawFrames.length} frames, optimizing...`);
 
       // Optimize frames
       const optimizedPaths = await optimizeFrames(
@@ -135,20 +137,24 @@ Requires video download capability for frame extraction.`,
         );
       }
 
-      await reportProgress({ progress: 75, total: 100 });
+      await progress(70, 'Filtering and deduplicating frames...');
 
       // OCR
-      const ocrResults = await extractTextFromFrames(frames, ocrLanguage).catch((e: unknown) => {
+      await progress(75, `Running OCR on ${frames.length} frames...`);
+      const ocrResults = await extractTextFromFrames(frames, ocrLanguage, (completed, total) => {
+        const pct = 75 + Math.round((completed / total) * 15);
+        progress(pct, `OCR: processing frame ${completed}/${total}...`);
+      }).catch((e: unknown) => {
         warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
         return [];
       });
 
-      await reportProgress({ progress: 90, total: 100 });
+      await progress(92, 'Building annotated timeline...');
 
       // Build mini-timeline for this range
       const timeline = buildAnnotatedTimeline(transcriptSegment, frames, ocrResults);
 
-      await reportProgress({ progress: 100, total: 100 });
+      await progress(100, 'Moment analysis complete');
 
       // Build response
       const textData = {

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -19,6 +19,7 @@ import type { IAnalysisResult } from '../types.js';
 import { AnalysisCache, cacheKey } from '../utils/cache.js';
 import { filterAnalysisResult } from '../utils/field-filter.js';
 import type { AnalysisField } from '../utils/field-filter.js';
+import { createProgressReporter } from '../utils/progress.js';
 import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 
 const cache = new AnalysisCache();
@@ -124,6 +125,7 @@ Use options.forceRefresh to bypass the cache.`,
       openWorldHint: true,
     },
     execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url, options } = args;
       const detail = options?.detail ?? 'standard';
       const forceRefresh = options?.forceRefresh ?? false;
@@ -175,7 +177,7 @@ Use options.forceRefresh to bypass the cache.`,
       let tempDir: string | null = null;
 
       try {
-        await reportProgress({ progress: 0, total: 100 });
+        await progress(0, 'Starting video analysis...');
 
         // Fetch metadata, transcript, comments in parallel
         const [metadata, transcript, comments, chapters, aiSummary] = await Promise.all([
@@ -207,7 +209,7 @@ Use options.forceRefresh to bypass the cache.`,
           adapter.getAiSummary(url).catch(() => null),
         ]);
 
-        await reportProgress({ progress: 40, total: 100 });
+        await progress(35, 'Metadata and transcript fetched');
 
         // Apply transcript limit for brief mode
         const limitedTranscript =
@@ -239,7 +241,7 @@ Use options.forceRefresh to bypass the cache.`,
             videoPath = await adapter.downloadVideo(url, tempDir);
 
             if (videoPath) {
-              await reportProgress({ progress: 60, total: 100 });
+              await progress(50, 'Video downloaded, extracting frames...');
 
               // Probe duration if metadata didn't provide it
               if (metadata.duration === 0) {
@@ -268,7 +270,7 @@ Use options.forceRefresh to bypass the cache.`,
                     return [];
                   });
 
-              await reportProgress({ progress: 80, total: 100 });
+              await progress(70, `Extracted ${rawFrames.length} frames, optimizing...`);
 
               if (rawFrames.length > 0) {
                 const optimizedPaths = await optimizeFrames(
@@ -292,7 +294,7 @@ Use options.forceRefresh to bypass the cache.`,
 
           // Strategy 2: Browser-based extraction (fallback)
           if (!framesExtracted && metadata.duration > 0) {
-            await reportProgress({ progress: 60, total: 100 });
+            await progress(50, 'Extracting frames via browser fallback...');
 
             const timestamps = generateTimestamps(metadata.duration, maxFrames);
             const browserFrames = await extractBrowserFrames(url, tempDir, {
@@ -304,7 +306,7 @@ Use options.forceRefresh to bypass the cache.`,
               return [];
             });
 
-            await reportProgress({ progress: 80, total: 100 });
+            await progress(70, `Browser extracted ${browserFrames.length} frames`);
 
             if (browserFrames.length > 0) {
               result.frames = browserFrames;
@@ -344,23 +346,30 @@ Use options.forceRefresh to bypass the cache.`,
               );
             }
 
-            await reportProgress({ progress: 85, total: 100 });
+            await progress(80, 'Filtering and deduplicating frames...');
 
             // OCR: extract text visible on screen
             if (config.includeOcr) {
-              result.ocrResults = await extractTextFromFrames(result.frames, ocrLanguage).catch(
-                (e: unknown) => {
-                  warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
-                  return [];
+              await progress(85, `Running OCR on ${result.frames.length} frames...`);
+              result.ocrResults = await extractTextFromFrames(
+                result.frames,
+                ocrLanguage,
+                (completed, total) => {
+                  const pct = 85 + Math.round((completed / total) * 8);
+                  progress(pct, `OCR: processing frame ${completed}/${total}...`);
                 },
-              );
+              ).catch((e: unknown) => {
+                warnings.push(`OCR failed: ${e instanceof Error ? e.message : String(e)}`);
+                return [];
+              });
             }
 
-            await reportProgress({ progress: 95, total: 100 });
+            await progress(93, 'OCR complete');
           }
 
           // Build annotated timeline
           if (config.includeTimeline) {
+            await progress(95, 'Building annotated timeline...');
             result.timeline = buildAnnotatedTimeline(
               result.transcript,
               result.frames,
@@ -391,7 +400,7 @@ Use options.forceRefresh to bypass the cache.`,
           }
         }
 
-        await reportProgress({ progress: 100, total: 100 });
+        await progress(100, 'Analysis complete');
 
         // Cache the full result
         cache.set(key, result);

--- a/src/tools/get-frame-at.ts
+++ b/src/tools/get-frame-at.ts
@@ -5,8 +5,8 @@ import { getAdapter } from '../adapters/adapter.interface.js';
 import { extractBrowserFrames } from '../processors/browser-frame-extractor.js';
 import { extractFrameAt, parseTimestamp } from '../processors/frame-extractor.js';
 import { optimizeFrame } from '../processors/image-optimizer.js';
-import { createTempDir } from '../utils/temp-files.js';
-import { getTempFilePath } from '../utils/temp-files.js';
+import { createProgressReporter } from '../utils/progress.js';
+import { createTempDir, getTempFilePath } from '../utils/temp-files.js';
 
 const GetFrameAtSchema = z.object({
   url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
@@ -45,11 +45,12 @@ Returns: A single image of the video frame at the specified timestamp.`,
       openWorldHint: true,
     },
     execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url, timestamp } = args;
 
       const adapter = getAdapter(url);
 
-      await reportProgress({ progress: 0, total: 100 });
+      await progress(0, 'Starting frame extraction...');
 
       const tempDir = await createTempDir();
 
@@ -58,13 +59,13 @@ Returns: A single image of the video frame at the specified timestamp.`,
         const videoPath = await adapter.downloadVideo(url, tempDir);
 
         if (videoPath) {
-          await reportProgress({ progress: 50, total: 100 });
+          await progress(50, `Extracting frame at ${timestamp}...`);
 
           const frame = await extractFrameAt(videoPath, tempDir, timestamp);
           const optimizedPath = getTempFilePath(tempDir, `opt_frame_at.jpg`);
           await optimizeFrame(frame.filePath, optimizedPath);
 
-          await reportProgress({ progress: 100, total: 100 });
+          await progress(100, 'Frame extracted');
 
           return {
             content: [
@@ -76,14 +77,14 @@ Returns: A single image of the video frame at the specified timestamp.`,
       }
 
       // Strategy 2: Browser-based extraction (fallback)
-      await reportProgress({ progress: 30, total: 100 });
+      await progress(30, 'Extracting frame via browser fallback...');
       const seconds = parseTimestamp(timestamp);
       const browserFrames = await extractBrowserFrames(url, tempDir, {
         timestamps: [seconds],
       });
 
       if (browserFrames.length > 0) {
-        await reportProgress({ progress: 100, total: 100 });
+        await progress(100, 'Frame extracted');
         return {
           content: [
             {

--- a/src/tools/get-frame-burst.ts
+++ b/src/tools/get-frame-burst.ts
@@ -5,6 +5,7 @@ import { getAdapter } from '../adapters/adapter.interface.js';
 import { extractBrowserFrames } from '../processors/browser-frame-extractor.js';
 import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
+import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
 
 const GetFrameBurstSchema = z.object({
@@ -56,12 +57,13 @@ Returns: N images evenly distributed between the from and to timestamps.`,
       openWorldHint: true,
     },
     execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url, from, to, count } = args;
       const frameCount = count ?? 5;
 
       const adapter = getAdapter(url);
 
-      await reportProgress({ progress: 0, total: 100 });
+      await progress(0, `Starting burst extraction (${from} → ${to})...`);
 
       const tempDir = await createTempDir();
 
@@ -70,18 +72,18 @@ Returns: N images evenly distributed between the from and to timestamps.`,
         const videoPath = await adapter.downloadVideo(url, tempDir);
 
         if (videoPath) {
-          await reportProgress({ progress: 40, total: 100 });
+          await progress(40, 'Video downloaded, extracting burst frames...');
 
           const frames = await extractFrameBurst(videoPath, tempDir, from, to, frameCount);
 
-          await reportProgress({ progress: 70, total: 100 });
+          await progress(70, `Extracted ${frames.length} frames, optimizing...`);
 
           const optimizedPaths = await optimizeFrames(
             frames.map((f) => f.filePath),
             tempDir,
           );
 
-          await reportProgress({ progress: 100, total: 100 });
+          await progress(100, 'Burst extraction complete');
 
           const content: (
             | { type: 'text'; text: string }
@@ -102,7 +104,7 @@ Returns: N images evenly distributed between the from and to timestamps.`,
       }
 
       // Strategy 2: Browser-based extraction (fallback)
-      await reportProgress({ progress: 30, total: 100 });
+      await progress(30, 'Extracting frames via browser fallback...');
       const fromSeconds = parseTimestamp(from);
       const toSeconds = parseTimestamp(to);
       const interval = (toSeconds - fromSeconds) / Math.max(frameCount - 1, 1);
@@ -113,7 +115,7 @@ Returns: N images evenly distributed between the from and to timestamps.`,
       const browserFrames = await extractBrowserFrames(url, tempDir, { timestamps });
 
       if (browserFrames.length > 0) {
-        await reportProgress({ progress: 100, total: 100 });
+        await progress(100, 'Burst extraction complete');
 
         const content: (
           | { type: 'text'; text: string }

--- a/src/tools/get-frames.ts
+++ b/src/tools/get-frames.ts
@@ -11,6 +11,7 @@ import {
   probeVideoDuration,
 } from '../processors/frame-extractor.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
+import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
 
 const GetFramesSchema = z.object({
@@ -61,6 +62,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       openWorldHint: true,
     },
     execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url, options } = args;
       const maxFrames = options?.maxFrames ?? 20;
       const threshold = options?.threshold ?? 0.1;
@@ -77,7 +79,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       const warnings: string[] = [];
       const tempDir = await createTempDir();
 
-      await reportProgress({ progress: 0, total: 100 });
+      await progress(0, 'Starting frame extraction...');
 
       // Get metadata for duration (needed for browser fallback)
       const metadata = await adapter.getMetadata(url).catch(() => ({
@@ -94,7 +96,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       if (adapter.capabilities.videoDownload) {
         const videoPath = await adapter.downloadVideo(url, tempDir);
         if (videoPath) {
-          await reportProgress({ progress: 50, total: 100 });
+          await progress(40, 'Video downloaded, extracting frames...');
 
           if (metadata.duration === 0) {
             const duration = await probeVideoDuration(videoPath).catch(() => 0);
@@ -134,7 +136,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
 
       // Strategy 2: Browser fallback
       if (frames.length === 0 && metadata.duration > 0) {
-        await reportProgress({ progress: 50, total: 100 });
+        await progress(40, 'Extracting frames via browser fallback...');
         const timestamps = generateTimestamps(metadata.duration, maxFrames);
         frames = await extractBrowserFrames(url, tempDir, { timestamps }).catch((e: unknown) => {
           warnings.push(`Browser extraction failed: ${e instanceof Error ? e.message : String(e)}`);
@@ -143,6 +145,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       }
 
       // Filter black/blank frames
+      await progress(80, 'Filtering and deduplicating frames...');
       if (frames.length > 0) {
         const blackResult = await filterBlackFrames(frames).catch(() => ({
           frames,
@@ -165,7 +168,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
         }
       }
 
-      await reportProgress({ progress: 100, total: 100 });
+      await progress(100, 'Frames extracted');
 
       if (frames.length === 0) {
         throw new UserError(

--- a/src/tools/get-metadata.ts
+++ b/src/tools/get-metadata.ts
@@ -2,6 +2,7 @@ import type { FastMCP } from 'fastmcp';
 import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
+import { createProgressReporter } from '../utils/progress.js';
 
 const GetMetadataSchema = z.object({
   url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
@@ -24,7 +25,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       idempotentHint: true,
       openWorldHint: true,
     },
-    execute: async (args) => {
+    execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url } = args;
 
       let adapter;
@@ -36,6 +38,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       }
 
       const warnings: string[] = [];
+
+      await progress(0, 'Fetching video metadata...');
 
       const [metadata, comments, chapters, aiSummary] = await Promise.all([
         adapter.getMetadata(url).catch((e: unknown) => {
@@ -55,6 +59,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
         adapter.getChapters(url).catch(() => []),
         adapter.getAiSummary(url).catch(() => null),
       ]);
+
+      await progress(100, 'Metadata fetched');
 
       return {
         content: [

--- a/src/tools/get-transcript.ts
+++ b/src/tools/get-transcript.ts
@@ -3,6 +3,7 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
 import { extractAudioTrack, transcribeAudio } from '../processors/audio-transcriber.js';
+import { createProgressReporter } from '../utils/progress.js';
 import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 
 const GetTranscriptSchema = z.object({
@@ -29,7 +30,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       idempotentHint: true,
       openWorldHint: true,
     },
-    execute: async (args) => {
+    execute: async (args, { reportProgress }) => {
+      const progress = createProgressReporter(reportProgress);
       const { url } = args;
 
       let adapter;
@@ -42,6 +44,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
 
       const warnings: string[] = [];
 
+      await progress(0, 'Fetching transcript...');
+
       // Try native transcript first
       let transcript = await adapter.getTranscript(url).catch((e: unknown) => {
         warnings.push(
@@ -50,13 +54,17 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
         return [];
       });
 
+      await progress(40, 'Native transcript fetched');
+
       // Whisper fallback if no native transcript
       if (transcript.length === 0 && adapter.capabilities.videoDownload) {
         let tempDir: string | null = null;
         try {
+          await progress(45, 'No native transcript, downloading video for Whisper...');
           tempDir = await createTempDir();
           const videoPath = await adapter.downloadVideo(url, tempDir);
           if (videoPath) {
+            await progress(65, 'Transcribing audio with Whisper...');
             const audioPath = await extractAudioTrack(videoPath, tempDir);
             transcript = await transcribeAudio(audioPath);
             if (transcript.length > 0) {
@@ -75,6 +83,8 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
       if (transcript.length === 0) {
         warnings.push('No transcript available for this video.');
       }
+
+      await progress(100, 'Transcript complete');
 
       return {
         content: [

--- a/src/utils/progress.test.ts
+++ b/src/utils/progress.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProgressReporter } from './progress.js';
+
+describe('createProgressReporter', () => {
+  it('calls reportProgress with progress and total', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined);
+    const progress = createProgressReporter(mock);
+
+    await progress(50);
+
+    expect(mock).toHaveBeenCalledWith({ progress: 50, total: 100 });
+  });
+
+  it('includes message when provided', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined);
+    const progress = createProgressReporter(mock);
+
+    await progress(75, 'Extracting frames...');
+
+    expect(mock).toHaveBeenCalledWith({
+      progress: 75,
+      total: 100,
+      message: 'Extracting frames...',
+    });
+  });
+
+  it('omits message field when not provided', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined);
+    const progress = createProgressReporter(mock);
+
+    await progress(0);
+
+    const call = mock.mock.calls[0][0];
+    expect(call).not.toHaveProperty('message');
+  });
+
+  it('uses custom total', async () => {
+    const mock = vi.fn().mockResolvedValue(undefined);
+    const progress = createProgressReporter(mock, 200);
+
+    await progress(100, 'Halfway');
+
+    expect(mock).toHaveBeenCalledWith({ progress: 100, total: 200, message: 'Halfway' });
+  });
+});

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,0 +1,18 @@
+/**
+ * Progress reporting utility with descriptive messages.
+ *
+ * The MCP spec supports an optional `message` field in progress notifications.
+ * FastMCP's TypeScript type omits it, but the runtime passes it through via spread.
+ */
+
+type ReportProgressFn = (progress: { progress: number; total?: number }) => Promise<void>;
+
+export function createProgressReporter(reportProgress: ReportProgressFn, total = 100) {
+  return async (progress: number, message?: string): Promise<void> => {
+    const payload: { progress: number; total: number; message?: string } = { progress, total };
+    if (message) {
+      payload.message = message;
+    }
+    await reportProgress(payload as { progress: number; total?: number });
+  };
+}


### PR DESCRIPTION
## Summary
- Adds descriptive progress messages to all 7 MCP tools, so clients see real-time status updates like "Running OCR on 5 frames..." instead of just a progress bar
- New `createProgressReporter` utility wraps FastMCP's `reportProgress` with MCP spec `message` field support
- `get_transcript` and `get_metadata` now report progress (previously had none)
- OCR processor accepts `onProgress` callback for per-frame granularity in `analyze_video` and `analyze_moment`

### Before
```
User: "Analyze this video"
[...30-60 seconds of silence...]
Result appears
```

### After
```
User: "Analyze this video"
[2s]  Starting video analysis...
[5s]  Metadata and transcript fetched
[10s] Video downloaded, extracting frames...
[15s] Extracted 8 frames, optimizing...
[18s] Running OCR on 8 frames...
[20s] OCR: processing frame 3/8...
[25s] Building annotated timeline...
[26s] Analysis complete
```

## Test plan
- [x] `npm run check` — all 197 tests pass, format/lint/typecheck/knip clean
- [x] `npm run test:smoke` — server starts and responds
- [x] New unit tests for `createProgressReporter` utility (4 tests)
- [ ] Manual test with Claude Desktop or Claude Code to verify progress messages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)