### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ MCP server for video analysis — extracts transcripts, key frames, and metadata
 
 No existing video MCP combines **transcripts + visual frames + metadata** in one tool. This one does.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/guimatheus92-mcp-video-analyzer).
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/guimatheus92-mcp-video-analyzer)