### PR TITLE
Add local video file support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,38 @@
+# Normalize line endings: store text as LF in the repo and check out as LF on
+# every OS, regardless of core.autocrlf. This prevents CRLF working-tree files
+# on Windows, which otherwise fail Prettier's format:check (and `npm run check`
+# / `prepublishOnly`). Repo blobs are already LF, so this is not a renormalization.
+* text=auto eol=lf
+
+# Binary assets — never line-ending-normalize these.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.pdf  binary
+*.woff  binary
+*.woff2 binary
+*.ttf  binary
+*.eot  binary
+*.otf  binary
+
+# Video / audio fixtures and assets.
+*.mp4  binary
+*.webm binary
+*.mov  binary
+*.mkv  binary
+*.avi  binary
+*.m4v  binary
+*.wmv  binary
+*.flv  binary
+*.mpeg binary
+*.mpg  binary
+*.m2ts binary
+*.mts  binary
+*.3gp  binary
+*.ogv  binary
+*.mp3  binary
+*.wav  binary
+*.m4a  binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-MCP server for video analysis — extracts transcripts, key frames, metadata, OCR text, and annotated timelines from video URLs (Loom, direct .mp4/.webm).
+MCP server for video analysis — extracts transcripts, key frames, metadata, OCR text, and annotated timelines from video URLs (Loom, direct links) and local video files.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -176,9 +176,11 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 |--------|:----------:|:--------:|:--------:|:------:|:----:|
 | **Loom** | Yes | Yes | Yes | Yes | None |
 | **Direct URL** (.mp4, .webm, .mov) | No | Duration only | No | Yes | None |
-| **Local file** (absolute path or `file://` URI) | Whisper fallback only | Filename + duration | No | Yes | None |
+| **Local file** (absolute path or `file://` URI) | Sidecar `.vtt`/`.srt` or Whisper fallback | Probed via ffmpeg (duration, dims, codec, audio presence) | No | Yes | None |
 
 > **Local files**: pass an absolute path (e.g., `/Users/you/clip.mp4`) or a `file://` URI as the `url` argument to any tool. Relative paths are rejected — the server's working directory is unpredictable from the MCP client. Note that any caller of the MCP server can ask it to read any file the server process has access to.
+>
+> **Sidecar transcripts**: if a `clip.vtt`, `clip.srt`, `clip.en.vtt`, etc. lives next to `clip.mp4`, it's used as the transcript automatically — no Whisper roundtrip needed. SRT is converted to VTT in-memory.
 
 ### Frame Extraction Strategies
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 > **Local files**: pass an absolute path (e.g., `/Users/you/clip.mp4`) or a `file://` URI as the `url` argument to any tool. Relative paths are rejected — the server's working directory is unpredictable from the MCP client. Note that any caller of the MCP server can ask it to read any file the server process has access to.
 >
 > **Sidecar transcripts**: if a `clip.vtt`, `clip.srt`, `clip.en.vtt`, etc. lives next to `clip.mp4`, it's used as the transcript automatically — no Whisper roundtrip needed. SRT is converted to VTT in-memory.
+>
+> **Embedded subtitles**: if no sidecar is found and the container has an embedded subtitle stream (common in `.mkv` / `.mov` / `.mp4` from screen recorders), it's transmuxed to VTT via ffmpeg and used as the transcript.
 
 ### Frame Extraction Strategies
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Featured in [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#-multimedia-process).
 
-MCP server for video analysis — extracts transcripts, key frames, and metadata from video URLs. Supports Loom, direct video files (.mp4, .webm), and more.
+MCP server for video analysis — extracts transcripts, key frames, and metadata from video URLs and local video files. Supports Loom, direct video URLs (.mp4, .webm, .mov), and absolute paths to local video files.
 
 No existing video MCP combines **transcripts + visual frames + metadata** in one tool. This one does.
 
@@ -170,12 +170,15 @@ For motion, vibration, animations, or fast scrolling — burst mode captures N f
 
 Results are cached in memory for 10 minutes. Subsequent calls with the same URL and options return instantly. Use `forceRefresh: true` to bypass the cache.
 
-## Supported Platforms
+## Supported Sources
 
-| Platform | Transcript | Metadata | Comments | Frames | Auth |
-|----------|:----------:|:--------:|:--------:|:------:|:----:|
+| Source | Transcript | Metadata | Comments | Frames | Auth |
+|--------|:----------:|:--------:|:--------:|:------:|:----:|
 | **Loom** | Yes | Yes | Yes | Yes | None |
-| **Direct URL** (.mp4, .webm) | No | Duration only | No | Yes | None |
+| **Direct URL** (.mp4, .webm, .mov) | No | Duration only | No | Yes | None |
+| **Local file** (absolute path or `file://` URI) | Whisper fallback only | Filename + duration | No | Yes | None |
+
+> **Local files**: pass an absolute path (e.g., `/Users/you/clip.mp4`) or a `file://` URI as the `url` argument to any tool. Relative paths are rejected — the server's working directory is unpredictable from the MCP client. Note that any caller of the MCP server can ask it to read any file the server process has access to.
 
 ### Frame Extraction Strategies
 
@@ -272,10 +275,11 @@ src/
 │   ├── get-frames.ts           # Frames-only (scene-change or dense)
 │   ├── get-frame-at.ts         # Single frame at timestamp
 │   └── get-frame-burst.ts      # N frames in a time range
-├── adapters/                   # Platform-specific logic
+├── adapters/                   # Source-specific logic
 │   ├── adapter.interface.ts    # IVideoAdapter interface + registry
 │   ├── loom.adapter.ts         # Loom: authless GraphQL
-│   └── direct.adapter.ts       # Direct URL: any mp4/webm link
+│   ├── direct.adapter.ts       # Direct URL: any mp4/webm link
+│   └── local-file.adapter.ts   # Local files: absolute path or file:// URI
 ├── processors/                 # Shared processing
 │   ├── frame-extractor.ts      # ffmpeg scene detection + dense + burst extraction
 │   ├── browser-frame-extractor.ts # Headless Chrome fallback for frames

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Featured in [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#-multimedia-process).
 
-MCP server for video analysis — extracts transcripts, key frames, and metadata from video URLs and local video files. Supports Loom, direct video URLs (.mp4, .webm, .mov), and absolute paths to local video files.
+MCP server for video analysis — extracts transcripts, key frames, and metadata from video URLs and local video files. Supports Loom, direct video URLs (.mp4, .mov, .mkv, .webm, and other common formats), and absolute paths to local video files.
 
 No existing video MCP combines **transcripts + visual frames + metadata** in one tool. This one does.
 
@@ -175,7 +175,7 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 | Source | Transcript | Metadata | Comments | Frames | Auth |
 |--------|:----------:|:--------:|:--------:|:------:|:----:|
 | **Loom** | Yes | Yes | Yes | Yes | None |
-| **Direct URL** (.mp4, .webm, .mov) | No | Duration only | No | Yes | None |
+| **Direct URL** (.mp4, .mov, .mkv, .webm, …) | No | Duration only | No | Yes | None |
 | **Local file** (absolute path or `file://` URI) | Sidecar `.vtt`/`.srt` or Whisper fallback | Probed via ffmpeg (duration, dims, codec, audio presence) | No | Yes | None |
 
 > **Local files**: pass an absolute path (e.g., `/Users/you/clip.mp4`) or a `file://` URI as the `url` argument to any tool. Relative paths are rejected — the server's working directory is unpredictable from the MCP client. Note that any caller of the MCP server can ask it to read any file the server process has access to.
@@ -183,6 +183,8 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 > **Sidecar transcripts**: if a `clip.vtt`, `clip.srt`, `clip.en.vtt`, etc. lives next to `clip.mp4`, it's used as the transcript automatically — no Whisper roundtrip needed. SRT is converted to VTT in-memory.
 >
 > **Embedded subtitles**: if no sidecar is found and the container has an embedded subtitle stream (common in `.mkv` / `.mov` / `.mp4` from screen recorders), it's transmuxed to VTT via ffmpeg and used as the transcript.
+>
+> **Recognized extensions** (local files and direct URLs): `.mp4` `.mov` `.mkv` `.webm` `.avi` `.m4v` `.wmv` `.flv` `.mpeg` `.mpg` `.m2ts` `.mts` `.3gp` `.ogv`. The extension only gates routing — ffmpeg does the actual demuxing, so most common containers work. `.ts` is excluded to avoid colliding with TypeScript source files.
 
 ### Frame Extraction Strategies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-video-analyzer",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-video-analyzer",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.2.0",
@@ -2317,7 +2317,6 @@
       "integrity": "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2377,7 +2376,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2724,7 +2722,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3464,8 +3461,7 @@
       "version": "0.0.1581282",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
       "integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3749,7 +3745,6 @@
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4021,7 +4016,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4822,7 +4816,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6330,7 +6323,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7341,7 +7333,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -7401,7 +7392,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7530,7 +7520,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -7606,7 +7595,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/src/adapters/adapter.interface.test.ts
+++ b/src/adapters/adapter.interface.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 
 describe('adapter registry', () => {
   it('throws UserError for unsupported URLs when no adapters registered', () => {
-    expect(() => getAdapter('https://example.com')).toThrow('Unsupported video URL');
+    expect(() => getAdapter('https://example.com')).toThrow('Unsupported video source');
   });
 
   it('returns Loom adapter for loom.com URLs', () => {
@@ -32,7 +32,7 @@ describe('adapter registry', () => {
     registerAdapter(new LoomAdapter());
     registerAdapter(new DirectAdapter());
 
-    expect(() => getAdapter('https://example.com/page')).toThrow('Unsupported video URL');
+    expect(() => getAdapter('https://example.com/page')).toThrow('Unsupported video source');
   });
 
   it('returns first matching adapter (Loom before Direct)', () => {

--- a/src/adapters/adapter.interface.ts
+++ b/src/adapters/adapter.interface.ts
@@ -33,7 +33,7 @@ export function getAdapter(url: string): IVideoAdapter {
     }
   }
   throw new UserError(
-    `Unsupported video URL: "${url}". Supported platforms: Loom (loom.com/share/...), direct video files (.mp4, .webm, .mov).`,
+    `Unsupported video source: "${url}". Supported: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and absolute local paths or file:// URIs to video files.`,
   );
 }
 

--- a/src/adapters/adapter.interface.ts
+++ b/src/adapters/adapter.interface.ts
@@ -5,10 +5,11 @@ import type {
   ITranscriptEntry,
   IVideoComment,
   IVideoMetadata,
+  Platform,
 } from '../types.js';
 
 export interface IVideoAdapter {
-  readonly name: string;
+  readonly name: Platform;
   readonly capabilities: IAdapterCapabilities;
 
   canHandle(url: string): boolean;

--- a/src/adapters/local-file.adapter.test.ts
+++ b/src/adapters/local-file.adapter.test.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LocalFileAdapter } from './local-file.adapter.js';
+
+describe('LocalFileAdapter', () => {
+  const adapter = new LocalFileAdapter();
+  let tmp: string;
+  let videoPath: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'local-adapter-'));
+    videoPath = join(tmp, 'demo.mp4');
+    writeFileSync(videoPath, 'fake video bytes');
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  describe('canHandle', () => {
+    it('returns true for absolute paths to video files', () => {
+      expect(adapter.canHandle(videoPath)).toBe(true);
+    });
+
+    it('returns true for file:// URIs to video files', () => {
+      expect(adapter.canHandle(pathToFileURL(videoPath).href)).toBe(true);
+    });
+
+    it('returns false for HTTP URLs', () => {
+      expect(adapter.canHandle('https://example.com/video.mp4')).toBe(false);
+    });
+
+    it('returns false for Loom URLs', () => {
+      expect(adapter.canHandle('https://www.loom.com/share/abc123')).toBe(false);
+    });
+
+    it('returns false for relative paths', () => {
+      expect(adapter.canHandle('./video.mp4')).toBe(false);
+    });
+
+    it('returns false for absolute paths to non-video files', () => {
+      expect(adapter.canHandle('/tmp/notes.txt')).toBe(false);
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('returns basename as title and platform="local"', async () => {
+      const metadata = await adapter.getMetadata(videoPath);
+      expect(metadata.platform).toBe('local');
+      expect(metadata.title).toBe('demo.mp4');
+      expect(metadata.duration).toBe(0);
+      expect(metadata.url).toBe(videoPath);
+    });
+
+    it('handles file:// URIs', async () => {
+      const fileUri = pathToFileURL(videoPath).href;
+      const metadata = await adapter.getMetadata(fileUri);
+      expect(metadata.title).toBe('demo.mp4');
+      expect(metadata.url).toBe(fileUri);
+    });
+  });
+
+  describe('getTranscript / getComments / getChapters / getAiSummary', () => {
+    it('all return empty/null', async () => {
+      expect(await adapter.getTranscript(videoPath)).toEqual([]);
+      expect(await adapter.getComments(videoPath)).toEqual([]);
+      expect(await adapter.getChapters(videoPath)).toEqual([]);
+      expect(await adapter.getAiSummary(videoPath)).toBeNull();
+    });
+  });
+
+  describe('downloadVideo', () => {
+    it('returns the path as-is for an absolute path', async () => {
+      const result = await adapter.downloadVideo(videoPath, tmp);
+      expect(result).toBe(videoPath);
+    });
+
+    it('resolves file:// URIs to fs paths', async () => {
+      const result = await adapter.downloadVideo(pathToFileURL(videoPath).href, tmp);
+      expect(result).toBe(videoPath);
+    });
+
+    it('throws UserError when the file does not exist', async () => {
+      await expect(adapter.downloadVideo('/tmp/does-not-exist-xyz.mp4', tmp)).rejects.toThrow(
+        /not found/i,
+      );
+    });
+
+    it('throws UserError when the path is a directory', async () => {
+      const dir = join(tmp, 'subdir.mp4');
+      mkdirSync(dir);
+      await expect(adapter.downloadVideo(dir, tmp)).rejects.toThrow(/not a regular file/i);
+    });
+  });
+});

--- a/src/adapters/local-file.adapter.test.ts
+++ b/src/adapters/local-file.adapter.test.ts
@@ -75,9 +75,21 @@ describe('LocalFileAdapter', () => {
     });
   });
 
-  describe('getTranscript / getComments / getChapters / getAiSummary', () => {
-    it('all return empty/null', async () => {
+  describe('getTranscript', () => {
+    it('returns [] when no sidecar exists', async () => {
       expect(await adapter.getTranscript(videoPath)).toEqual([]);
+    });
+
+    it('picks up a sidecar .vtt next to the video', async () => {
+      writeFileSync(join(tmp, 'demo.vtt'), 'WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nHello.\n');
+      const entries = await adapter.getTranscript(videoPath);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].text).toBe('Hello.');
+    });
+  });
+
+  describe('getComments / getChapters / getAiSummary', () => {
+    it('all return empty/null', async () => {
       expect(await adapter.getComments(videoPath)).toEqual([]);
       expect(await adapter.getChapters(videoPath)).toEqual([]);
       expect(await adapter.getAiSummary(videoPath)).toBeNull();

--- a/src/adapters/local-file.adapter.test.ts
+++ b/src/adapters/local-file.adapter.test.ts
@@ -51,7 +51,6 @@ describe('LocalFileAdapter', () => {
       const metadata = await adapter.getMetadata(videoPath);
       expect(metadata.platform).toBe('local');
       expect(metadata.title).toBe('demo.mp4');
-      expect(metadata.duration).toBe(0);
       expect(metadata.url).toBe(videoPath);
     });
 
@@ -60,6 +59,19 @@ describe('LocalFileAdapter', () => {
       const metadata = await adapter.getMetadata(fileUri);
       expect(metadata.title).toBe('demo.mp4');
       expect(metadata.url).toBe(fileUri);
+    });
+
+    it('reports file size from stat', async () => {
+      const metadata = await adapter.getMetadata(videoPath);
+      expect(metadata.fileSizeBytes).toBe('fake video bytes'.length);
+    });
+
+    it('falls back to duration=0 when ffmpeg cannot probe (corrupt content)', async () => {
+      // The fake "video" written above isn't a valid container — probe fails
+      // gracefully and we still get a sensible metadata object.
+      const metadata = await adapter.getMetadata(videoPath);
+      expect(metadata.duration).toBe(0);
+      expect(metadata.durationFormatted).toBe('0:00');
     });
   });
 

--- a/src/adapters/local-file.adapter.test.ts
+++ b/src/adapters/local-file.adapter.test.ts
@@ -73,6 +73,12 @@ describe('LocalFileAdapter', () => {
       expect(metadata.duration).toBe(0);
       expect(metadata.durationFormatted).toBe('0:00');
     });
+
+    it('throws UserError when the file does not exist', async () => {
+      await expect(adapter.getMetadata('/tmp/does-not-exist-xyz.mp4')).rejects.toThrow(
+        /not found/i,
+      );
+    });
   });
 
   describe('getTranscript', () => {

--- a/src/adapters/local-file.adapter.ts
+++ b/src/adapters/local-file.adapter.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { UserError } from 'fastmcp';
+import { extractEmbeddedSubtitle } from '../processors/embedded-subtitles.js';
 import { formatTimestamp, probeVideo } from '../processors/frame-extractor.js';
 import type {
   IAdapterCapabilities,
@@ -69,7 +70,13 @@ export class LocalFileAdapter implements IVideoAdapter {
 
   async getTranscript(input: string): Promise<ITranscriptEntry[]> {
     const path = this.resolve(input);
-    return findSidecarTranscript(path);
+
+    // Sidecars first — if the user dropped a transcript next to the file
+    // they likely want that one used over anything muxed in the container.
+    const sidecar = await findSidecarTranscript(path);
+    if (sidecar.length > 0) return sidecar;
+
+    return extractEmbeddedSubtitle(path);
   }
 
   async getComments(_input: string): Promise<IVideoComment[]> {

--- a/src/adapters/local-file.adapter.ts
+++ b/src/adapters/local-file.adapter.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { UserError } from 'fastmcp';
+import { formatTimestamp, probeVideo } from '../processors/frame-extractor.js';
 import type {
   IAdapterCapabilities,
   IChapter,
@@ -18,9 +19,10 @@ import type { IVideoAdapter } from './adapter.interface.js';
  * unchanged — frame extraction and audio transcoding then run via the same
  * ffmpeg pipeline used for downloaded videos.
  *
- * Duration probing via ffprobe could be added here, but the existing tools
- * already fall back to `probeVideoDuration(videoPath)` when metadata reports 0,
- * which gives the same result for free.
+ * `getMetadata` runs an ffmpeg probe to populate duration, dimensions, fps,
+ * codecs, audio-track presence, and container creation_time when available.
+ * This is cheap (~50ms) because the file is already on disk and lets callers
+ * skip the Whisper fallback for silent recordings.
  */
 export class LocalFileAdapter implements IVideoAdapter {
   readonly name = 'local';
@@ -39,12 +41,26 @@ export class LocalFileAdapter implements IVideoAdapter {
 
   async getMetadata(input: string): Promise<IVideoMetadata> {
     const path = this.resolve(input);
+
+    const stat = statSync(path, { throwIfNoEntry: false });
+    const fileSizeBytes = stat?.isFile() ? stat.size : undefined;
+
+    const probe = await probeVideo(path).catch(() => null);
+
     return {
       platform: 'local',
       title: basename(path),
-      duration: 0,
-      durationFormatted: '0:00',
+      duration: probe?.duration ?? 0,
+      durationFormatted: formatTimestamp(Math.floor(probe?.duration ?? 0)),
       url: input,
+      width: probe?.width,
+      height: probe?.height,
+      fps: probe?.fps,
+      videoCodec: probe?.videoCodec,
+      audioCodec: probe?.audioCodec,
+      hasAudio: probe?.hasAudio,
+      creationTime: probe?.creationTime,
+      fileSizeBytes,
     };
   }
 

--- a/src/adapters/local-file.adapter.ts
+++ b/src/adapters/local-file.adapter.ts
@@ -9,6 +9,7 @@ import type {
   IVideoComment,
   IVideoMetadata,
 } from '../types.js';
+import { findSidecarTranscript } from '../utils/sidecar-transcripts.js';
 import { detectPlatform, toLocalPath } from '../utils/url-detector.js';
 import type { IVideoAdapter } from './adapter.interface.js';
 
@@ -27,7 +28,9 @@ import type { IVideoAdapter } from './adapter.interface.js';
 export class LocalFileAdapter implements IVideoAdapter {
   readonly name = 'local';
   readonly capabilities: IAdapterCapabilities = {
-    transcript: false,
+    // Sidecar `.vtt`/`.srt` files next to the video are picked up; if none
+    // exist this still returns [] and Whisper fallback handles it.
+    transcript: true,
     metadata: true,
     comments: false,
     chapters: false,
@@ -64,8 +67,9 @@ export class LocalFileAdapter implements IVideoAdapter {
     };
   }
 
-  async getTranscript(_input: string): Promise<ITranscriptEntry[]> {
-    return [];
+  async getTranscript(input: string): Promise<ITranscriptEntry[]> {
+    const path = this.resolve(input);
+    return findSidecarTranscript(path);
   }
 
   async getComments(_input: string): Promise<IVideoComment[]> {

--- a/src/adapters/local-file.adapter.ts
+++ b/src/adapters/local-file.adapter.ts
@@ -1,0 +1,85 @@
+import { existsSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
+import { UserError } from 'fastmcp';
+import type {
+  IAdapterCapabilities,
+  IChapter,
+  ITranscriptEntry,
+  IVideoComment,
+  IVideoMetadata,
+} from '../types.js';
+import { detectPlatform, toLocalPath } from '../utils/url-detector.js';
+import type { IVideoAdapter } from './adapter.interface.js';
+
+/**
+ * Adapter for local video files. Accepts absolute fs paths and `file://` URIs.
+ *
+ * Local files are already on disk, so `downloadVideo` returns the resolved path
+ * unchanged — frame extraction and audio transcoding then run via the same
+ * ffmpeg pipeline used for downloaded videos.
+ *
+ * Duration probing via ffprobe could be added here, but the existing tools
+ * already fall back to `probeVideoDuration(videoPath)` when metadata reports 0,
+ * which gives the same result for free.
+ */
+export class LocalFileAdapter implements IVideoAdapter {
+  readonly name = 'local';
+  readonly capabilities: IAdapterCapabilities = {
+    transcript: false,
+    metadata: true,
+    comments: false,
+    chapters: false,
+    aiSummary: false,
+    videoDownload: true,
+  };
+
+  canHandle(input: string): boolean {
+    return detectPlatform(input) === 'local';
+  }
+
+  async getMetadata(input: string): Promise<IVideoMetadata> {
+    const path = this.resolve(input);
+    return {
+      platform: 'local',
+      title: basename(path),
+      duration: 0,
+      durationFormatted: '0:00',
+      url: input,
+    };
+  }
+
+  async getTranscript(_input: string): Promise<ITranscriptEntry[]> {
+    return [];
+  }
+
+  async getComments(_input: string): Promise<IVideoComment[]> {
+    return [];
+  }
+
+  async getChapters(_input: string): Promise<IChapter[]> {
+    return [];
+  }
+
+  async getAiSummary(_input: string): Promise<string | null> {
+    return null;
+  }
+
+  async downloadVideo(input: string, _destDir: string): Promise<string | null> {
+    const path = this.resolve(input);
+    if (!existsSync(path)) {
+      throw new UserError(`Local video file not found: ${path}`);
+    }
+    if (!statSync(path).isFile()) {
+      throw new UserError(`Local video path is not a regular file: ${path}`);
+    }
+    return path;
+  }
+
+  private resolve(input: string): string {
+    const path = toLocalPath(input);
+    if (path === null) {
+      throw new UserError(`Not a local video path: ${input}`);
+    }
+    return path;
+  }
+}

--- a/src/adapters/local-file.adapter.ts
+++ b/src/adapters/local-file.adapter.ts
@@ -21,16 +21,17 @@ import type { IVideoAdapter } from './adapter.interface.js';
  * unchanged — frame extraction and audio transcoding then run via the same
  * ffmpeg pipeline used for downloaded videos.
  *
- * `getMetadata` runs an ffmpeg probe to populate duration, dimensions, fps,
- * codecs, audio-track presence, and container creation_time when available.
- * This is cheap (~50ms) because the file is already on disk and lets callers
- * skip the Whisper fallback for silent recordings.
+ * `getMetadata` runs a single short-lived ffmpeg probe (no transcode) to
+ * populate duration, dimensions, fps, codecs, audio-track presence, and
+ * container creation_time when available. It's far cheaper than Whisper and
+ * lets callers skip the Whisper fallback for silent recordings.
  */
 export class LocalFileAdapter implements IVideoAdapter {
   readonly name = 'local';
   readonly capabilities: IAdapterCapabilities = {
-    // Sidecar `.vtt`/`.srt` files next to the video are picked up; if none
-    // exist this still returns [] and Whisper fallback handles it.
+    // Sidecar `.vtt`/`.srt` files next to the video are picked up first, then
+    // an embedded subtitle track; if neither exists this returns [] and the
+    // tool-layer Whisper fallback handles it.
     transcript: true,
     metadata: true,
     comments: false,
@@ -46,8 +47,15 @@ export class LocalFileAdapter implements IVideoAdapter {
   async getMetadata(input: string): Promise<IVideoMetadata> {
     const path = this.resolve(input);
 
+    // A missing file is a hard error, not a silent zero-duration result —
+    // throwing here lets the tool layer surface it via warnings[] (and keeps
+    // those warning paths from being dead code). A present-but-unprobeable
+    // file still degrades gracefully below.
     const stat = statSync(path, { throwIfNoEntry: false });
-    const fileSizeBytes = stat?.isFile() ? stat.size : undefined;
+    if (!stat?.isFile()) {
+      throw new UserError(`Local video file not found: ${path}`);
+    }
+    const fileSizeBytes = stat.size;
 
     const probe = await probeVideo(path).catch(() => null);
 

--- a/src/processors/embedded-subtitles.test.ts
+++ b/src/processors/embedded-subtitles.test.ts
@@ -1,0 +1,77 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { FIXTURES_DIR } from '../../test/helpers/index.js';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
+import { extractEmbeddedSubtitle } from './embedded-subtitles.js';
+
+const execFile = promisify(execFileCb);
+const require = createRequire(import.meta.url);
+const ffmpegPath: string = require('ffmpeg-static') as string;
+
+describe('extractEmbeddedSubtitle', () => {
+  let tempDir: string;
+  let videoWithSubs: string;
+
+  beforeAll(async () => {
+    tempDir = await createTempDir('embedded-subs-');
+
+    // Build a fixture: tiny.mp4 + a tiny SRT muxed into an mkv container
+    // (mp4 doesn't natively support srt streams; mkv does and is universally
+    // available in ffmpeg-static).
+    const srtPath = join(tempDir, 'subs.srt');
+    writeFileSync(
+      srtPath,
+      [
+        '1',
+        '00:00:00,000 --> 00:00:01,500',
+        'Hello from embedded subs.',
+        '',
+        '2',
+        '00:00:01,500 --> 00:00:03,000',
+        'Second cue.',
+        '',
+      ].join('\n'),
+    );
+
+    videoWithSubs = join(tempDir, 'with-subs.mkv');
+    await execFile(ffmpegPath, [
+      '-y',
+      '-loglevel',
+      'error',
+      '-i',
+      join(FIXTURES_DIR, 'tiny.mp4'),
+      '-i',
+      srtPath,
+      '-c:v',
+      'copy',
+      '-c:s',
+      'srt',
+      videoWithSubs,
+    ]);
+  });
+
+  afterAll(async () => {
+    if (tempDir) await cleanupTempDir(tempDir);
+  });
+
+  it('extracts cues from a container with an embedded subtitle stream', async () => {
+    const entries = await extractEmbeddedSubtitle(videoWithSubs);
+    expect(entries.length).toBeGreaterThanOrEqual(2);
+    expect(entries[0].text).toBe('Hello from embedded subs.');
+    expect(entries[1].text).toBe('Second cue.');
+  });
+
+  it('returns [] for a video with no subtitle stream', async () => {
+    const entries = await extractEmbeddedSubtitle(join(FIXTURES_DIR, 'tiny.mp4'));
+    expect(entries).toEqual([]);
+  });
+
+  it('returns [] for a non-existent file (errors are non-fatal)', async () => {
+    const entries = await extractEmbeddedSubtitle('/nonexistent/file.mp4');
+    expect(entries).toEqual([]);
+  });
+});

--- a/src/processors/embedded-subtitles.ts
+++ b/src/processors/embedded-subtitles.ts
@@ -16,9 +16,10 @@ const ffmpegPath: string = require('ffmpeg-static') as string;
  * inside the video container. ffmpeg can transmux them to WebVTT directly
  * — orders of magnitude cheaper than Whisper.
  *
- * `-map 0:s:0?` makes the subtitle mapping optional: when no subtitle
- * stream exists, ffmpeg produces an empty/header-only VTT that the parser
- * resolves to []. Errors from ffmpeg are non-fatal and degrade to [].
+ * `-map 0:s:0?` makes the subtitle mapping optional so stream selection
+ * doesn't fail outright. When no subtitle stream exists ffmpeg still errors
+ * (it refuses to write an output with no streams) and exits non-zero — the
+ * `catch` below degrades that, and any other ffmpeg failure, to [].
  */
 export async function extractEmbeddedSubtitle(videoPath: string): Promise<ITranscriptEntry[]> {
   try {

--- a/src/processors/embedded-subtitles.ts
+++ b/src/processors/embedded-subtitles.ts
@@ -1,0 +1,46 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { promisify } from 'node:util';
+import type { ITranscriptEntry } from '../types.js';
+import { parseVtt } from '../utils/vtt-parser.js';
+
+const execFile = promisify(execFileCb);
+
+const require = createRequire(import.meta.url);
+const ffmpegPath: string = require('ffmpeg-static') as string;
+
+/**
+ * Extract the first embedded subtitle stream from a container as a transcript.
+ *
+ * Many recording tools (OBS, ScreenFlow, Riverside) ship caption tracks
+ * inside the video container. ffmpeg can transmux them to WebVTT directly
+ * — orders of magnitude cheaper than Whisper.
+ *
+ * `-map 0:s:0?` makes the subtitle mapping optional: when no subtitle
+ * stream exists, ffmpeg produces an empty/header-only VTT that the parser
+ * resolves to []. Errors from ffmpeg are non-fatal and degrade to [].
+ */
+export async function extractEmbeddedSubtitle(videoPath: string): Promise<ITranscriptEntry[]> {
+  try {
+    const { stdout } = await execFile(
+      ffmpegPath,
+      ['-loglevel', 'error', '-i', videoPath, '-map', '0:s:0?', '-f', 'webvtt', '-'],
+      { timeout: 30000, maxBuffer: 50 * 1024 * 1024 },
+    );
+    return parseVtt(normalizeVttTimestamps(stdout));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * ffmpeg's webvtt muxer emits short-form `MM:SS.mmm` cues for sub-1-hour
+ * videos, but the VTT parser only matches the long form `HH:MM:SS.mmm`.
+ * Normalize so both spec-valid forms reach the parser.
+ */
+function normalizeVttTimestamps(vtt: string): string {
+  return vtt.replace(
+    /(?<![\d:])(\d{2}):(\d{2}\.\d{3})\s*-->\s*(\d{2}):(\d{2}\.\d{3})/g,
+    '00:$1:$2 --> 00:$3:$4',
+  );
+}

--- a/src/processors/frame-extractor.test.ts
+++ b/src/processors/frame-extractor.test.ts
@@ -8,6 +8,7 @@ import {
   extractDenseFrames,
   extractFrameAt,
   formatTimestamp,
+  parseProbeFromStderr,
   parseSceneTimestamps,
   parseTimestamp,
   probeVideo,
@@ -111,6 +112,53 @@ describe('probeVideo', () => {
 
   it('throws for non-existent file', async () => {
     await expect(probeVideo('/nonexistent/video.mp4')).rejects.toThrow();
+  });
+});
+
+describe('parseProbeFromStderr', () => {
+  it('parses a stream with audio and creation_time', () => {
+    const stderr = [
+      "Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'sample.mp4':",
+      '  Metadata:',
+      '    creation_time   : 2024-01-15T10:30:00.000000Z',
+      '  Duration: 00:01:23.45, start: 0.000000, bitrate: 1234 kb/s',
+      '  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1920x1080, 5000 kb/s, 30 fps, 30 tbr, 15360 tbn (default)',
+      '  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s (default)',
+    ].join('\n');
+
+    const probe = parseProbeFromStderr(stderr);
+
+    expect(probe.duration).toBeCloseTo(83.45, 1);
+    expect(probe.width).toBe(1920);
+    expect(probe.height).toBe(1080);
+    expect(probe.fps).toBe(30);
+    expect(probe.videoCodec).toBe('h264');
+    expect(probe.hasAudio).toBe(true);
+    expect(probe.audioCodec).toBe('aac');
+    expect(probe.creationTime).toBe('2024-01-15T10:30:00.000000Z');
+  });
+
+  it('parses resolution/codec even when ffmpeg omits fps (VFR / tbr-only stream)', () => {
+    const stderr = [
+      "Input #0, matroska,webm, from 'novfr.mkv':",
+      '  Duration: 00:00:10.00, start: 0.000000, bitrate: 800 kb/s',
+      '  Stream #0:0: Video: vp9 (Profile 0), yuv420p(tv), 1280x720, SAR 1:1 DAR 16:9, 25 tbr, 1k tbn (default)',
+    ].join('\n');
+
+    const probe = parseProbeFromStderr(stderr);
+
+    expect(probe.width).toBe(1280);
+    expect(probe.height).toBe(720);
+    expect(probe.videoCodec).toBe('vp9');
+    expect(probe.fps).toBeUndefined();
+    expect(probe.hasAudio).toBe(false);
+  });
+
+  it('returns zeroed/empty result for unparseable stderr', () => {
+    const probe = parseProbeFromStderr('garbage with no recognizable streams');
+    expect(probe.duration).toBe(0);
+    expect(probe.hasAudio).toBe(false);
+    expect(probe.width).toBeUndefined();
   });
 });
 

--- a/src/processors/frame-extractor.test.ts
+++ b/src/processors/frame-extractor.test.ts
@@ -10,6 +10,7 @@ import {
   formatTimestamp,
   parseSceneTimestamps,
   parseTimestamp,
+  probeVideo,
   probeVideoDuration,
 } from './frame-extractor.js';
 
@@ -87,6 +88,29 @@ describe('probeVideoDuration', () => {
 
   it('throws for non-existent file', async () => {
     await expect(probeVideoDuration('/nonexistent/video.mp4')).rejects.toThrow();
+  });
+});
+
+describe('probeVideo', () => {
+  it('returns full metadata for tiny.mp4 fixture', async () => {
+    const probe = await probeVideo(join(FIXTURES_DIR, 'tiny.mp4'));
+
+    expect(probe.duration).toBeGreaterThan(2);
+    expect(probe.duration).toBeLessThan(4);
+    expect(probe.width).toBe(320);
+    expect(probe.height).toBe(240);
+    expect(probe.fps).toBe(10);
+    expect(probe.videoCodec).toBe('h264');
+  });
+
+  it('reports hasAudio=false for tiny.mp4 (no audio track)', async () => {
+    const probe = await probeVideo(join(FIXTURES_DIR, 'tiny.mp4'));
+    expect(probe.hasAudio).toBe(false);
+    expect(probe.audioCodec).toBeUndefined();
+  });
+
+  it('throws for non-existent file', async () => {
+    await expect(probeVideo('/nonexistent/video.mp4')).rejects.toThrow();
   });
 });
 

--- a/src/processors/frame-extractor.ts
+++ b/src/processors/frame-extractor.ts
@@ -70,6 +70,80 @@ function parseDurationFromStderr(stderr: string): number {
   return hours * 3600 + minutes * 60 + seconds + centiseconds / 100;
 }
 
+export interface IVideoProbeResult {
+  duration: number;
+  width?: number;
+  height?: number;
+  fps?: number;
+  videoCodec?: string;
+  hasAudio: boolean;
+  audioCodec?: string;
+  creationTime?: string;
+}
+
+/**
+ * Probe a video file's metadata by parsing ffmpeg's stderr.
+ *
+ * `ffmpeg-static` doesn't ship `ffprobe`, so we invoke ffmpeg with no output
+ * — it prints stream info to stderr and exits with code 1 ("At least one
+ * output file must be specified"). This is the same trick `probeVideoDuration`
+ * uses; we just parse more fields.
+ */
+export async function probeVideo(videoPath: string): Promise<IVideoProbeResult> {
+  let stderr: string;
+  try {
+    ({ stderr } = await execFile(ffmpegPath, ['-i', videoPath], { timeout: 30000 }));
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'stderr' in error) {
+      stderr = (error as { stderr: string }).stderr;
+    } else {
+      throw new Error(`Failed to probe video: ${videoPath}`, { cause: error });
+    }
+  }
+
+  // ffmpeg only prints "Input #N, ..." when it successfully opens the file.
+  // If that line is missing, the path was bad / format unrecognized — surface
+  // the error rather than returning a half-empty result.
+  if (!/^Input #\d+/m.test(stderr)) {
+    throw new Error(`Failed to probe video: ${videoPath}`);
+  }
+
+  return parseProbeFromStderr(stderr);
+}
+
+function parseProbeFromStderr(stderr: string): IVideoProbeResult {
+  const result: IVideoProbeResult = {
+    duration: parseDurationFromStderr(stderr),
+    hasAudio: false,
+  };
+
+  // Only parse the input section — ffmpeg may also print output streams.
+  const inputSection = stderr.split(/^Output #\d+/m)[0];
+
+  const videoMatch = inputSection.match(
+    /Stream #\d+:\d+(?:[^:]*)?: Video: (\S+?)(?:\s|,)[^\n]*?(\d{2,5})x(\d{2,5})[^\n]*?(\d+(?:\.\d+)?) fps/,
+  );
+  if (videoMatch) {
+    result.videoCodec = videoMatch[1].replace(/,$/, '');
+    result.width = parseInt(videoMatch[2], 10);
+    result.height = parseInt(videoMatch[3], 10);
+    result.fps = parseFloat(videoMatch[4]);
+  }
+
+  const audioMatch = inputSection.match(/Stream #\d+:\d+(?:[^:]*)?: Audio: (\S+?)(?:\s|,)/);
+  if (audioMatch) {
+    result.hasAudio = true;
+    result.audioCodec = audioMatch[1].replace(/,$/, '');
+  }
+
+  const creationMatch = inputSection.match(/creation_time\s*:\s*(\S+)/);
+  if (creationMatch) {
+    result.creationTime = creationMatch[1];
+  }
+
+  return result;
+}
+
 export function parseSceneTimestamps(stderr: string): number[] {
   const timestamps: number[] = [];
   const regex = /pts_time:(\d+(?:\.\d+)?)/g;

--- a/src/processors/frame-extractor.ts
+++ b/src/processors/frame-extractor.ts
@@ -111,7 +111,7 @@ export async function probeVideo(videoPath: string): Promise<IVideoProbeResult> 
   return parseProbeFromStderr(stderr);
 }
 
-function parseProbeFromStderr(stderr: string): IVideoProbeResult {
+export function parseProbeFromStderr(stderr: string): IVideoProbeResult {
   const result: IVideoProbeResult = {
     duration: parseDurationFromStderr(stderr),
     hasAudio: false,
@@ -121,13 +121,20 @@ function parseProbeFromStderr(stderr: string): IVideoProbeResult {
   const inputSection = stderr.split(/^Output #\d+/m)[0];
 
   const videoMatch = inputSection.match(
-    /Stream #\d+:\d+(?:[^:]*)?: Video: (\S+?)(?:\s|,)[^\n]*?(\d{2,5})x(\d{2,5})[^\n]*?(\d+(?:\.\d+)?) fps/,
+    /Stream #\d+:\d+(?:[^:]*)?: Video: (\S+?)(?:\s|,)[^\n]*?(\d{2,5})x(\d{2,5})/,
   );
   if (videoMatch) {
     result.videoCodec = videoMatch[1].replace(/,$/, '');
     result.width = parseInt(videoMatch[2], 10);
     result.height = parseInt(videoMatch[3], 10);
-    result.fps = parseFloat(videoMatch[4]);
+  }
+
+  // fps lives on the same Video line, but ffmpeg omits it for some streams
+  // (variable-frame-rate / certain MKV/MOV exports print only tbr/tbn).
+  // Parse it independently so a missing fps doesn't drop codec/resolution above.
+  const fpsMatch = inputSection.match(/: Video:[^\n]*?(\d+(?:\.\d+)?)\s*fps/);
+  if (fpsMatch) {
+    result.fps = parseFloat(fpsMatch[1]);
   }
 
   const audioMatch = inputSection.match(/Stream #\d+:\d+(?:[^:]*)?: Audio: (\S+?)(?:\s|,)/);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,7 @@
 import { FastMCP } from 'fastmcp';
 import { registerAdapter } from './adapters/adapter.interface.js';
 import { DirectAdapter } from './adapters/direct.adapter.js';
+import { LocalFileAdapter } from './adapters/local-file.adapter.js';
 import { LoomAdapter } from './adapters/loom.adapter.js';
 import { registerAnalyzeMoment } from './tools/analyze-moment.js';
 import { registerAnalyzeVideo } from './tools/analyze-video.js';
@@ -14,10 +15,10 @@ export function createServer(): FastMCP {
   const server = new FastMCP({
     name: 'mcp-video-analyzer',
     version: '0.2.5',
-    instructions: `Video analysis MCP server. Extracts transcripts, key frames, metadata, comments, OCR text, and annotated timelines from video URLs.
+    instructions: `Video analysis MCP server. Extracts transcripts, key frames, metadata, comments, OCR text, and annotated timelines from video URLs and local video files.
 
 AUTOMATIC BEHAVIOR — Do NOT wait for the user to ask:
-- When the user shares a video URL → call analyze_video immediately (detail="standard").
+- When the user shares a video URL or local video file path → call analyze_video immediately (detail="standard").
 - When discussing a specific moment in a video → call analyze_moment with the time range.
 - When the user asks "what happens at X:XX" → call get_frame_at or analyze_moment.
 - When the user asks to compare frames or see motion → call get_frame_burst.
@@ -26,9 +27,10 @@ AUTOMATIC BEHAVIOR — Do NOT wait for the user to ask:
 
 The AI should ALWAYS call the appropriate tool automatically — never ask "would you like me to analyze this video?" Just do it.
 
-Supported platforms:
+Supported sources:
 - Loom (loom.com/share/...) — transcript, metadata, comments, frames (no auth needed)
 - Direct video URLs (.mp4, .webm, .mov) — frame extraction, duration probing
+- Local video files — pass an absolute path (e.g., "/Users/you/clip.mp4") or a file:// URI; frame extraction + Whisper transcription work the same way
 
 Tools (choose the most efficient one for the task):
 - analyze_video: Full analysis. Use by default when a video URL appears. Returns transcript + frames + metadata + OCR + timeline.
@@ -55,6 +57,7 @@ Decision flow:
 
   // Register adapters (order matters: more specific first)
   registerAdapter(new LoomAdapter());
+  registerAdapter(new LocalFileAdapter());
   registerAdapter(new DirectAdapter());
 
   // Register tools

--- a/src/tools/analyze-moment.ts
+++ b/src/tools/analyze-moment.ts
@@ -9,9 +9,18 @@ import { extractTextFromFrames } from '../processors/frame-ocr.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
+import { isVideoSource } from '../utils/url-detector.js';
 
 const AnalyzeMomentSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
   from: z.string().describe('Start timestamp (e.g., "1:30")'),
   to: z.string().describe('End timestamp (e.g., "2:00")'),
   count: z
@@ -44,8 +53,7 @@ Use this when you need to understand exactly what happens between two timestamps
 
 Example: analyze_moment(url, "1:30", "2:00", 10) → 10 frames + transcript + OCR for that 30s window
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).
-Requires video download capability for frame extraction.`,
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).`,
     parameters: AnalyzeMomentSchema,
     annotations: {
       title: 'Analyze Moment',

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -15,7 +15,7 @@ import {
 } from '../processors/frame-extractor.js';
 import { extractTextFromFrames } from '../processors/frame-ocr.js';
 import { optimizeFrames } from '../processors/image-optimizer.js';
-import type { IAnalysisResult } from '../types.js';
+import type { IAnalysisResult, IVideoMetadata } from '../types.js';
 import { AnalysisCache, cacheKey } from '../utils/cache.js';
 import { filterAnalysisResult } from '../utils/field-filter.js';
 import type { AnalysisField } from '../utils/field-filter.js';
@@ -190,7 +190,7 @@ Use options.forceRefresh to bypass the cache.`,
 
         // Fetch metadata, transcript, comments in parallel
         const [metadata, transcript, comments, chapters, aiSummary] = await Promise.all([
-          adapter.getMetadata(url).catch((e: unknown) => {
+          adapter.getMetadata(url).catch((e: unknown): IVideoMetadata => {
             warnings.push(
               `Failed to fetch metadata: ${e instanceof Error ? e.message : String(e)}`,
             );
@@ -396,8 +396,10 @@ Use options.forceRefresh to bypass the cache.`,
           }
         }
 
-        // Whisper fallback: if no transcript and we have a video file
-        if (result.transcript.length === 0 && videoPath) {
+        // Whisper fallback: if no transcript and we have a video file.
+        // Skip when the source is known to have no audio track (saves 30s+
+        // of needless transcription on silent screencasts).
+        if (result.transcript.length === 0 && videoPath && metadata.hasAudio !== false) {
           try {
             const audioPath = await extractAudioTrack(videoPath, tempDir ?? '');
             const whisperTranscript = await transcribeAudio(audioPath);

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -21,6 +21,7 @@ import { filterAnalysisResult } from '../utils/field-filter.js';
 import type { AnalysisField } from '../utils/field-filter.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
+import { isVideoSource, toLocalPath } from '../utils/url-detector.js';
 
 const cache = new AnalysisCache();
 
@@ -90,7 +91,15 @@ const AnalyzeOptionsSchema = z
   .optional();
 
 const AnalyzeVideoSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
   options: AnalyzeOptionsSchema.describe('Analysis options'),
 });
 
@@ -107,7 +116,7 @@ Returns structured data about the video content:
 - Metadata (title, duration, platform)
 - Comments from viewers (if available)
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).
 
 Detail levels:
 - "brief": metadata + truncated transcript only (fast, no video download)
@@ -186,7 +195,7 @@ Use options.forceRefresh to bypass the cache.`,
               `Failed to fetch metadata: ${e instanceof Error ? e.message : String(e)}`,
             );
             return {
-              platform: adapter.name as 'loom' | 'direct' | 'unknown',
+              platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
               title: 'Unknown',
               duration: 0,
               durationFormatted: '0:00',
@@ -292,8 +301,11 @@ Use options.forceRefresh to bypass the cache.`,
             }
           }
 
-          // Strategy 2: Browser-based extraction (fallback)
-          if (!framesExtracted && metadata.duration > 0) {
+          // Strategy 2: Browser-based extraction (fallback) — skipped for local
+          // files since puppeteer.goto() can't load fs paths reliably and the
+          // ffmpeg path above always works for files already on disk.
+          const isLocal = toLocalPath(url) !== null;
+          if (!framesExtracted && !isLocal && metadata.duration > 0) {
             await progress(50, 'Extracting frames via browser fallback...');
 
             const timestamps = generateTimestamps(metadata.duration, maxFrames);

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -195,7 +195,7 @@ Use options.forceRefresh to bypass the cache.`,
               `Failed to fetch metadata: ${e instanceof Error ? e.message : String(e)}`,
             );
             return {
-              platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
+              platform: adapter.name,
               title: 'Unknown',
               duration: 0,
               durationFormatted: '0:00',
@@ -409,9 +409,15 @@ Use options.forceRefresh to bypass the cache.`,
                 'Transcript generated via Whisper fallback (no native transcript available).',
               );
             }
-          } catch {
-            // Audio extraction or transcription failed — not critical
+          } catch (e: unknown) {
+            warnings.push(`Whisper fallback failed: ${e instanceof Error ? e.message : String(e)}`);
           }
+        }
+
+        // Surface the absence of a transcript explicitly rather than returning
+        // an empty array with no explanation.
+        if (result.transcript.length === 0) {
+          warnings.push('No transcript available for this video.');
         }
 
         await progress(100, 'Analysis complete');

--- a/src/tools/get-frame-at.ts
+++ b/src/tools/get-frame-at.ts
@@ -7,9 +7,18 @@ import { extractFrameAt, parseTimestamp } from '../processors/frame-extractor.js
 import { optimizeFrame } from '../processors/image-optimizer.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir, getTempFilePath } from '../utils/temp-files.js';
+import { isVideoSource, toLocalPath } from '../utils/url-detector.js';
 
 const GetFrameAtSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
   timestamp: z
     .string()
     .describe('Timestamp to extract frame at (e.g., "1:23", "0:05", "01:23:45")'),
@@ -28,11 +37,10 @@ export function registerGetFrameAt(server: FastMCP): void {
 Useful for inspecting what's on screen at a particular moment. The AI reads the transcript,
 identifies a critical moment, and requests the exact frame at that timestamp.
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).
-Requires video download capability — direct URLs work best.
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).
 
 Args:
-  - url: Video URL
+  - url: Video source (URL or local path)
   - timestamp: Time position (e.g., "1:23", "0:05", "01:23:45")
 
 Returns: A single image of the video frame at the specified timestamp.`,
@@ -76,7 +84,14 @@ Returns: A single image of the video frame at the specified timestamp.`,
         }
       }
 
-      // Strategy 2: Browser-based extraction (fallback)
+      // Strategy 2: Browser-based extraction (fallback) — not applicable to
+      // local files (puppeteer.goto() can't load fs paths reliably).
+      if (toLocalPath(url) !== null) {
+        throw new UserError(
+          'Failed to extract frame from local video. Install ffmpeg or check that the file is a valid video.',
+        );
+      }
+
       await progress(30, 'Extracting frame via browser fallback...');
       const seconds = parseTimestamp(timestamp);
       const browserFrames = await extractBrowserFrames(url, tempDir, {

--- a/src/tools/get-frame-burst.ts
+++ b/src/tools/get-frame-burst.ts
@@ -7,9 +7,18 @@ import { extractFrameBurst, parseTimestamp } from '../processors/frame-extractor
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
+import { isVideoSource, toLocalPath } from '../utils/url-detector.js';
 
 const GetFrameBurstSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
   from: z.string().describe('Start timestamp (e.g., "0:15")'),
   to: z.string().describe('End timestamp (e.g., "0:17")'),
   count: z
@@ -38,11 +47,10 @@ Example: get_frame_burst(url, "0:15", "0:17", 10) → 10 frames in 2 seconds
 - AI sees the object in different positions across frames → understands the vibration
 - Works for: shaking, flickering, animations, fast scrolling, loading spinners
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).
-Requires video download capability — direct URLs work best.
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).
 
 Args:
-  - url: Video URL
+  - url: Video source (URL or local path)
   - from: Start timestamp (e.g., "0:15")
   - to: End timestamp (e.g., "0:17")
   - count: Number of frames (default: 5, max: 30)
@@ -103,7 +111,14 @@ Returns: N images evenly distributed between the from and to timestamps.`,
         }
       }
 
-      // Strategy 2: Browser-based extraction (fallback)
+      // Strategy 2: Browser-based extraction (fallback) — not applicable to
+      // local files (puppeteer.goto() can't load fs paths reliably).
+      if (toLocalPath(url) !== null) {
+        throw new UserError(
+          'Failed to extract frames from local video. Install ffmpeg or check that the file is a valid video.',
+        );
+      }
+
       await progress(30, 'Extracting frames via browser fallback...');
       const fromSeconds = parseTimestamp(from);
       const toSeconds = parseTimestamp(to);

--- a/src/tools/get-frames.ts
+++ b/src/tools/get-frames.ts
@@ -92,7 +92,7 @@ Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and 
 
       // Get metadata for duration (needed for browser fallback)
       const metadata = await adapter.getMetadata(url).catch(() => ({
-        platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
+        platform: adapter.name,
         title: 'Unknown',
         duration: 0,
         durationFormatted: '0:00',

--- a/src/tools/get-frames.ts
+++ b/src/tools/get-frames.ts
@@ -13,9 +13,18 @@ import {
 import { optimizeFrames } from '../processors/image-optimizer.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { createTempDir } from '../utils/temp-files.js';
+import { isVideoSource, toLocalPath } from '../utils/url-detector.js';
 
 const GetFramesSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
   options: z
     .object({
       maxFrames: z
@@ -52,7 +61,7 @@ Two extraction modes:
 
 Returns optimized, deduplicated JPEG frames.
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).`,
     parameters: GetFramesSchema,
     annotations: {
       title: 'Get Frames',
@@ -83,7 +92,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
 
       // Get metadata for duration (needed for browser fallback)
       const metadata = await adapter.getMetadata(url).catch(() => ({
-        platform: adapter.name as 'loom' | 'direct' | 'unknown',
+        platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
         title: 'Unknown',
         duration: 0,
         durationFormatted: '0:00',
@@ -134,8 +143,10 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
         }
       }
 
-      // Strategy 2: Browser fallback
-      if (frames.length === 0 && metadata.duration > 0) {
+      // Strategy 2: Browser fallback — skipped for local files since
+      // puppeteer.goto() can't load fs paths reliably.
+      const isLocal = toLocalPath(url) !== null;
+      if (frames.length === 0 && !isLocal && metadata.duration > 0) {
         await progress(40, 'Extracting frames via browser fallback...');
         const timestamps = generateTimestamps(metadata.duration, maxFrames);
         frames = await extractBrowserFrames(url, tempDir, { timestamps }).catch((e: unknown) => {

--- a/src/tools/get-metadata.ts
+++ b/src/tools/get-metadata.ts
@@ -3,9 +3,18 @@ import { UserError } from 'fastmcp';
 import { z } from 'zod';
 import { getAdapter } from '../adapters/adapter.interface.js';
 import { createProgressReporter } from '../utils/progress.js';
+import { isVideoSource } from '../utils/url-detector.js';
 
 const GetMetadataSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
 });
 
 export function registerGetMetadata(server: FastMCP): void {
@@ -16,7 +25,7 @@ export function registerGetMetadata(server: FastMCP): void {
 Returns structured metadata without downloading the video or extracting frames.
 Faster than analyze_video when you only need metadata.
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI).`,
     parameters: GetMetadataSchema,
     annotations: {
       title: 'Get Metadata',
@@ -45,7 +54,7 @@ Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
         adapter.getMetadata(url).catch((e: unknown) => {
           warnings.push(`Failed to fetch metadata: ${e instanceof Error ? e.message : String(e)}`);
           return {
-            platform: adapter.name as 'loom' | 'direct' | 'unknown',
+            platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
             title: 'Unknown',
             duration: 0,
             durationFormatted: '0:00',

--- a/src/tools/get-metadata.ts
+++ b/src/tools/get-metadata.ts
@@ -54,7 +54,7 @@ Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and 
         adapter.getMetadata(url).catch((e: unknown) => {
           warnings.push(`Failed to fetch metadata: ${e instanceof Error ? e.message : String(e)}`);
           return {
-            platform: adapter.name as 'loom' | 'direct' | 'local' | 'unknown',
+            platform: adapter.name,
             title: 'Unknown',
             duration: 0,
             durationFormatted: '0:00',

--- a/src/tools/get-transcript.ts
+++ b/src/tools/get-transcript.ts
@@ -30,7 +30,7 @@ Faster than analyze_video when you only need the transcript.
 If the platform has no native transcript, attempts Whisper fallback transcription
 (requires @huggingface/transformers, whisper CLI, or OPENAI_API_KEY).
 
-Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI). Local files have no native transcript — Whisper fallback is used.`,
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI). For local files a sidecar .vtt/.srt next to the file is used first, then an embedded subtitle track, and only then the Whisper fallback if neither exists.`,
     parameters: GetTranscriptSchema,
     annotations: {
       title: 'Get Transcript',
@@ -75,7 +75,9 @@ Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and 
           .catch(() => undefined);
 
         if (hasAudio === false) {
-          warnings.push('No audio track detected — skipped Whisper transcription.');
+          warnings.push(
+            'No audio track detected by the probe — skipped Whisper transcription. If the video does have audio, the probe may not have recognized the stream.',
+          );
         } else {
           let tempDir: string | null = null;
           try {

--- a/src/tools/get-transcript.ts
+++ b/src/tools/get-transcript.ts
@@ -5,9 +5,18 @@ import { getAdapter } from '../adapters/adapter.interface.js';
 import { extractAudioTrack, transcribeAudio } from '../processors/audio-transcriber.js';
 import { createProgressReporter } from '../utils/progress.js';
 import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
+import { isVideoSource } from '../utils/url-detector.js';
 
 const GetTranscriptSchema = z.object({
-  url: z.string().url().describe('Video URL (Loom share link or direct mp4/webm URL)'),
+  url: z
+    .string()
+    .refine(isVideoSource, {
+      message:
+        'Must be a Loom share URL, a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file',
+    })
+    .describe(
+      'Video source: Loom share link, direct .mp4/.webm/.mov URL, or absolute path to a local video file',
+    ),
 });
 
 export function registerGetTranscript(server: FastMCP): void {
@@ -21,7 +30,7 @@ Faster than analyze_video when you only need the transcript.
 If the platform has no native transcript, attempts Whisper fallback transcription
 (requires @huggingface/transformers, whisper CLI, or OPENAI_API_KEY).
 
-Supports: Loom (loom.com/share/...) and direct video URLs (.mp4, .webm, .mov).`,
+Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and local video files (absolute path or file:// URI). Local files have no native transcript — Whisper fallback is used.`,
     parameters: GetTranscriptSchema,
     annotations: {
       title: 'Get Transcript',

--- a/src/tools/get-transcript.ts
+++ b/src/tools/get-transcript.ts
@@ -65,27 +65,38 @@ Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and 
 
       await progress(40, 'Native transcript fetched');
 
-      // Whisper fallback if no native transcript
+      // Whisper fallback if no native transcript.
       if (transcript.length === 0 && adapter.capabilities.videoDownload) {
-        let tempDir: string | null = null;
-        try {
-          await progress(45, 'No native transcript, downloading video for Whisper...');
-          tempDir = await createTempDir();
-          const videoPath = await adapter.downloadVideo(url, tempDir);
-          if (videoPath) {
-            await progress(65, 'Transcribing audio with Whisper...');
-            const audioPath = await extractAudioTrack(videoPath, tempDir);
-            transcript = await transcribeAudio(audioPath);
-            if (transcript.length > 0) {
-              warnings.push(
-                'Transcript generated via Whisper fallback (no native transcript available).',
-              );
+        // Skip the fallback if the source advertises no audio track —
+        // a metadata probe is cheap; transcription is not.
+        const hasAudio = await adapter
+          .getMetadata(url)
+          .then((m) => m.hasAudio)
+          .catch(() => undefined);
+
+        if (hasAudio === false) {
+          warnings.push('No audio track detected — skipped Whisper transcription.');
+        } else {
+          let tempDir: string | null = null;
+          try {
+            await progress(45, 'No native transcript, downloading video for Whisper...');
+            tempDir = await createTempDir();
+            const videoPath = await adapter.downloadVideo(url, tempDir);
+            if (videoPath) {
+              await progress(65, 'Transcribing audio with Whisper...');
+              const audioPath = await extractAudioTrack(videoPath, tempDir);
+              transcript = await transcribeAudio(audioPath);
+              if (transcript.length > 0) {
+                warnings.push(
+                  'Transcript generated via Whisper fallback (no native transcript available).',
+                );
+              }
             }
+          } catch {
+            // Whisper fallback failed — not critical
+          } finally {
+            if (tempDir) await cleanupTempDir(tempDir).catch(() => undefined);
           }
-        } catch {
-          // Whisper fallback failed — not critical
-        } finally {
-          if (tempDir) await cleanupTempDir(tempDir).catch(() => undefined);
         }
       }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface ITranscriptEntry {
 }
 
 export interface IVideoMetadata {
-  platform: 'loom' | 'direct' | 'unknown';
+  platform: 'loom' | 'direct' | 'local' | 'unknown';
   title: string;
   description?: string;
   duration: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,16 @@ export interface IVideoMetadata {
   durationFormatted: string;
   url: string;
   thumbnailUrl?: string;
+  // Optional fields populated when the source is local and ffmpeg can probe
+  // the file directly. Adapters that don't have this info leave them undefined.
+  width?: number;
+  height?: number;
+  fps?: number;
+  videoCodec?: string;
+  audioCodec?: string;
+  hasAudio?: boolean;
+  creationTime?: string;
+  fileSizeBytes?: number;
 }
 
 export interface IVideoComment {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+/** Video sources the server can detect and route to a dedicated adapter. */
+export type Platform = 'loom' | 'direct' | 'local';
+
+/** Platform as reported in metadata; `'unknown'` is a fallback sentinel. */
+type MetadataPlatform = Platform | 'unknown';
+
 export interface ITranscriptEntry {
   time: string;
   endTime?: string;
@@ -6,7 +12,7 @@ export interface ITranscriptEntry {
 }
 
 export interface IVideoMetadata {
-  platform: 'loom' | 'direct' | 'local' | 'unknown';
+  platform: MetadataPlatform;
   title: string;
   description?: string;
   duration: number;

--- a/src/utils/cache.test.ts
+++ b/src/utils/cache.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IAnalysisResult } from '../types.js';
 import { AnalysisCache, cacheKey } from './cache.js';
@@ -163,5 +166,48 @@ describe('cacheKey', () => {
   it('handles URL without params', () => {
     const key = cacheKey('https://example.com/video.mp4');
     expect(key).toHaveLength(16);
+  });
+
+  describe('local file inputs', () => {
+    let tmp: string;
+    let videoPath: string;
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), 'cache-key-'));
+      videoPath = join(tmp, 'clip.mp4');
+      writeFileSync(videoPath, 'a');
+    });
+
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('produces a different key when the file size changes', () => {
+      const before = cacheKey(videoPath);
+      writeFileSync(videoPath, 'aaaa');
+      const after = cacheKey(videoPath);
+      expect(after).not.toBe(before);
+    });
+
+    it('produces a different key when only mtime changes', () => {
+      const before = cacheKey(videoPath);
+      // Bump mtime by 5 seconds without changing size
+      const future = new Date(Date.now() + 5000);
+      utimesSync(videoPath, future, future);
+      const after = cacheKey(videoPath);
+      expect(after).not.toBe(before);
+    });
+
+    it('produces the same key for the same file across calls', () => {
+      const a = cacheKey(videoPath);
+      const b = cacheKey(videoPath);
+      expect(a).toBe(b);
+    });
+
+    it('falls back to path-only key when the file is missing', () => {
+      const missing = join(tmp, 'does-not-exist.mp4');
+      const key = cacheKey(missing);
+      expect(key).toHaveLength(16);
+    });
   });
 });

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
+import { statSync } from 'node:fs';
 import type { IAnalysisResult } from '../types.js';
+import { toLocalPath } from './url-detector.js';
 
 interface CacheEntry {
   value: IAnalysisResult;
@@ -106,10 +108,26 @@ export class AnalysisCache {
 
 /**
  * Generate a deterministic cache key from a URL and optional parameters.
+ *
+ * For local file paths, mixes in `mtime` and `size` from `stat` so editing
+ * the file invalidates cached analysis. URL inputs are unaffected.
  */
 export function cacheKey(url: string, params?: Record<string, unknown>): string {
-  const input = params ? url + JSON.stringify(sortKeys(params)) : url;
+  const stamp = localFileStamp(url);
+  const base = stamp ? `${url}|${stamp}` : url;
+  const input = params ? base + JSON.stringify(sortKeys(params)) : base;
   return createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+function localFileStamp(input: string): string | null {
+  const path = toLocalPath(input);
+  if (!path) return null;
+  try {
+    const stat = statSync(path);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return null;
+  }
 }
 
 function sortKeys(obj: Record<string, unknown>): Record<string, unknown> {

--- a/src/utils/sidecar-transcripts.test.ts
+++ b/src/utils/sidecar-transcripts.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findSidecarTranscript, srtToVtt } from './sidecar-transcripts.js';
+
+describe('srtToVtt', () => {
+  it('converts SRT timestamps and prepends the VTT header', () => {
+    const srt = [
+      '1',
+      '00:00:01,500 --> 00:00:04,000',
+      'Hello world.',
+      '',
+      '2',
+      '00:00:05,000 --> 00:00:07,500',
+      'Second line.',
+    ].join('\n');
+
+    const vtt = srtToVtt(srt);
+    expect(vtt).toMatch(/^WEBVTT\n\n/);
+    expect(vtt).toContain('00:00:01.500 --> 00:00:04.000');
+    expect(vtt).toContain('00:00:05.000 --> 00:00:07.500');
+    expect(vtt).toContain('Hello world.');
+  });
+});
+
+describe('findSidecarTranscript', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'sidecar-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeFixture(name: string, content: string): string {
+    const path = join(tmp, name);
+    writeFileSync(path, content);
+    return path;
+  }
+
+  const sampleVtt = [
+    'WEBVTT',
+    '',
+    '00:00:00.000 --> 00:00:02.000',
+    'First.',
+    '',
+    '00:00:02.000 --> 00:00:04.000',
+    'Second.',
+  ].join('\n');
+
+  const sampleSrt = [
+    '1',
+    '00:00:00,000 --> 00:00:02,000',
+    'First.',
+    '',
+    '2',
+    '00:00:02,000 --> 00:00:04,000',
+    'Second.',
+  ].join('\n');
+
+  it('returns empty array when no sidecar exists', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    expect(await findSidecarTranscript(videoPath)).toEqual([]);
+  });
+
+  it('finds <stem>.vtt next to the video', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('clip.vtt', sampleVtt);
+
+    const entries = await findSidecarTranscript(videoPath);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toBe('First.');
+    expect(entries[1].text).toBe('Second.');
+  });
+
+  it('finds <stem>.srt and converts it to entries', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('clip.srt', sampleSrt);
+
+    const entries = await findSidecarTranscript(videoPath);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].text).toBe('First.');
+  });
+
+  it('prefers .vtt over .srt when both exist', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('clip.vtt', sampleVtt);
+    writeFixture('clip.srt', '1\n00:00:99,000 --> 00:00:99,000\nWRONG.');
+
+    const entries = await findSidecarTranscript(videoPath);
+    expect(entries[0].text).toBe('First.');
+  });
+
+  it('finds language-suffixed variants like <stem>.en.vtt', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('clip.en.vtt', sampleVtt);
+
+    const entries = await findSidecarTranscript(videoPath);
+    expect(entries).toHaveLength(2);
+  });
+
+  it('prefers a direct <stem>.vtt over a language-suffixed variant', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('clip.vtt', sampleVtt);
+    writeFixture('clip.en.vtt', 'WEBVTT\n\n00:00:00.000 --> 00:00:02.000\nWRONG.\n');
+
+    const entries = await findSidecarTranscript(videoPath);
+    expect(entries[0].text).toBe('First.');
+  });
+
+  it('does not match unrelated siblings', async () => {
+    const videoPath = writeFixture('clip.mp4', 'fake');
+    writeFixture('other.vtt', sampleVtt);
+
+    expect(await findSidecarTranscript(videoPath)).toEqual([]);
+  });
+});

--- a/src/utils/sidecar-transcripts.ts
+++ b/src/utils/sidecar-transcripts.ts
@@ -1,0 +1,92 @@
+import { readdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { basename, dirname, extname, join } from 'node:path';
+import type { ITranscriptEntry } from '../types.js';
+import { parseVtt } from './vtt-parser.js';
+
+/**
+ * Look for a transcript/caption file next to `videoPath`.
+ *
+ * Tries (in priority order):
+ *   1. <stem>.vtt
+ *   2. <stem>.srt
+ *   3. <stem>.<anything>.vtt — e.g. clip.en.vtt, clip.en-US.vtt
+ *   4. <stem>.<anything>.srt
+ *
+ * SRT files are converted to VTT in-memory before parsing.
+ *
+ * Returns [] when nothing is found. Read errors and parse errors are
+ * non-fatal — they degrade to "no sidecar".
+ */
+export async function findSidecarTranscript(videoPath: string): Promise<ITranscriptEntry[]> {
+  const dir = dirname(videoPath);
+  const stem = basename(videoPath, extname(videoPath));
+
+  const sidecar = pickSidecar(dir, stem);
+  if (!sidecar) return [];
+
+  try {
+    const raw = await readFile(sidecar.path, 'utf8');
+    const vtt = sidecar.format === 'srt' ? srtToVtt(raw) : raw;
+    return parseVtt(vtt);
+  } catch {
+    return [];
+  }
+}
+
+interface SidecarMatch {
+  path: string;
+  format: 'vtt' | 'srt';
+}
+
+function pickSidecar(dir: string, stem: string): SidecarMatch | null {
+  const direct: SidecarMatch[] = [
+    { path: join(dir, `${stem}.vtt`), format: 'vtt' },
+    { path: join(dir, `${stem}.srt`), format: 'srt' },
+  ];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const entrySet = new Set(entries);
+
+  for (const candidate of direct) {
+    if (entrySet.has(basename(candidate.path))) return candidate;
+  }
+
+  // Language/qualifier variants: <stem>.<anything>.vtt|srt — sorted for
+  // deterministic pick.
+  const prefix = `${stem}.`;
+  const variants: SidecarMatch[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    const rest = entry.slice(prefix.length);
+    if (!rest.includes('.')) continue;
+    if (rest.endsWith('.vtt')) variants.push({ path: join(dir, entry), format: 'vtt' });
+    else if (rest.endsWith('.srt')) variants.push({ path: join(dir, entry), format: 'srt' });
+  }
+  variants.sort((a, b) => {
+    if (a.format !== b.format) return a.format === 'vtt' ? -1 : 1;
+    return a.path.localeCompare(b.path);
+  });
+  return variants[0] ?? null;
+}
+
+/**
+ * Convert SRT to VTT in-memory. SRT differs from VTT only in:
+ *   - no `WEBVTT` header
+ *   - timestamps use `,` instead of `.` for milliseconds
+ *
+ * Anything more exotic (cue settings, styling) is handled by parseVtt's
+ * existing tag-stripping behavior.
+ */
+export function srtToVtt(srt: string): string {
+  const normalized = srt.replace(
+    /(\d{2}:\d{2}:\d{2}),(\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2}),(\d{3})/g,
+    '$1.$2 --> $3.$4',
+  );
+  return `WEBVTT\n\n${normalized}`;
+}

--- a/src/utils/url-detector.test.ts
+++ b/src/utils/url-detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { detectPlatform, extractLoomId } from './url-detector.js';
+import { detectPlatform, extractLoomId, isVideoSource, toLocalPath } from './url-detector.js';
 
 describe('detectPlatform', () => {
   it('detects Loom share URLs', () => {
@@ -68,6 +68,80 @@ describe('detectPlatform', () => {
 
   it('handles case-insensitive extensions', () => {
     expect(detectPlatform('https://example.com/VIDEO.MP4')).toBe('direct');
+  });
+
+  it('detects absolute POSIX paths to video files as local', () => {
+    expect(detectPlatform('/Users/me/Movies/clip.mp4')).toBe('local');
+    expect(detectPlatform('/tmp/video.webm')).toBe('local');
+  });
+
+  it('detects file:// URIs as local', () => {
+    expect(detectPlatform('file:///Users/me/Movies/clip.mp4')).toBe('local');
+    expect(detectPlatform('file:///tmp/video.mov')).toBe('local');
+  });
+
+  it('returns null for absolute paths that are not video files', () => {
+    expect(detectPlatform('/Users/me/notes.txt')).toBeNull();
+    expect(detectPlatform('/tmp/page.html')).toBeNull();
+  });
+
+  it('returns null for relative paths', () => {
+    expect(detectPlatform('./video.mp4')).toBeNull();
+    expect(detectPlatform('video.mp4')).toBeNull();
+    expect(detectPlatform('../movies/clip.mp4')).toBeNull();
+  });
+});
+
+describe('toLocalPath', () => {
+  it('returns the path unchanged for absolute POSIX paths', () => {
+    expect(toLocalPath('/tmp/video.mp4')).toBe('/tmp/video.mp4');
+  });
+
+  it('converts file:// URIs to fs paths', () => {
+    expect(toLocalPath('file:///tmp/video.mp4')).toBe('/tmp/video.mp4');
+  });
+
+  it('returns null for HTTP URLs', () => {
+    expect(toLocalPath('https://example.com/video.mp4')).toBeNull();
+  });
+
+  it('returns null for relative paths', () => {
+    expect(toLocalPath('./video.mp4')).toBeNull();
+    expect(toLocalPath('video.mp4')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(toLocalPath('')).toBeNull();
+  });
+});
+
+describe('isVideoSource', () => {
+  it('accepts Loom URLs', () => {
+    expect(isVideoSource('https://loom.com/share/abc123')).toBe(true);
+  });
+
+  it('accepts direct video URLs', () => {
+    expect(isVideoSource('https://example.com/video.mp4')).toBe(true);
+  });
+
+  it('accepts absolute paths to video files', () => {
+    expect(isVideoSource('/tmp/video.mp4')).toBe(true);
+  });
+
+  it('accepts file:// URIs to video files', () => {
+    expect(isVideoSource('file:///tmp/video.mp4')).toBe(true);
+  });
+
+  it('rejects relative paths', () => {
+    expect(isVideoSource('./video.mp4')).toBe(false);
+  });
+
+  it('rejects non-video URLs', () => {
+    expect(isVideoSource('https://example.com/page.html')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isVideoSource('')).toBe(false);
   });
 });
 

--- a/src/utils/url-detector.test.ts
+++ b/src/utils/url-detector.test.ts
@@ -44,6 +44,17 @@ describe('detectPlatform', () => {
     expect(detectPlatform('https://example.com/video.m4v')).toBe('direct');
   });
 
+  it('detects additional direct video container formats', () => {
+    for (const ext of ['wmv', 'flv', 'mpeg', 'mpg', 'm2ts', 'mts', '3gp', 'ogv']) {
+      expect(detectPlatform(`https://example.com/video.${ext}`)).toBe('direct');
+    }
+  });
+
+  it('does not treat .ts (TypeScript) paths as video', () => {
+    expect(detectPlatform('https://example.com/module.ts')).toBeNull();
+    expect(detectPlatform('/Users/me/src/index.ts')).toBeNull();
+  });
+
   it('returns null for YouTube URLs (unsupported in v0.1)', () => {
     expect(detectPlatform('https://www.youtube.com/watch?v=abc123')).toBeNull();
   });
@@ -75,6 +86,8 @@ describe('detectPlatform', () => {
   it('detects absolute POSIX paths to video files as local', () => {
     expect(detectPlatform('/Users/me/Movies/clip.mp4')).toBe('local');
     expect(detectPlatform('/tmp/video.webm')).toBe('local');
+    expect(detectPlatform('/tmp/recording.mkv')).toBe('local');
+    expect(detectPlatform('/tmp/camera.mts')).toBe('local');
   });
 
   it('detects file:// URIs as local', () => {

--- a/src/utils/url-detector.test.ts
+++ b/src/utils/url-detector.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { detectPlatform, extractLoomId, isVideoSource, toLocalPath } from './url-detector.js';
 
@@ -76,8 +78,17 @@ describe('detectPlatform', () => {
   });
 
   it('detects file:// URIs as local', () => {
-    expect(detectPlatform('file:///Users/me/Movies/clip.mp4')).toBe('local');
-    expect(detectPlatform('file:///tmp/video.mov')).toBe('local');
+    // Derive the URI from a real absolute path so it is valid on the host OS —
+    // a hardcoded POSIX `file://` literal throws under fileURLToPath on Windows.
+    expect(detectPlatform(pathToFileURL(resolve('Movies', 'clip.mp4')).href)).toBe('local');
+    expect(detectPlatform(pathToFileURL(resolve('tmp', 'video.mov')).href)).toBe('local');
+  });
+
+  // Windows drive paths are only absolute on win32; guard so the suite stays
+  // green on POSIX CI too.
+  (process.platform === 'win32' ? it : it.skip)('detects Windows drive paths as local', () => {
+    expect(detectPlatform('C:\\Users\\me\\clip.mp4')).toBe('local');
+    expect(detectPlatform('C:\\Users\\me\\notes.txt')).toBeNull();
   });
 
   it('returns null for absolute paths that are not video files', () => {
@@ -98,7 +109,8 @@ describe('toLocalPath', () => {
   });
 
   it('converts file:// URIs to fs paths', () => {
-    expect(toLocalPath('file:///tmp/video.mp4')).toBe('/tmp/video.mp4');
+    const abs = resolve('tmp', 'video.mp4');
+    expect(toLocalPath(pathToFileURL(abs).href)).toBe(abs);
   });
 
   it('returns null for HTTP URLs', () => {

--- a/src/utils/url-detector.ts
+++ b/src/utils/url-detector.ts
@@ -4,7 +4,26 @@ import type { Platform } from '../types.js';
 
 const LOOM_PATTERN = /^https?:\/\/(?:www\.)?loom\.com\/(?:share|embed)\/([a-f0-9-]+)/i;
 
-const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mov', '.avi', '.mkv', '.m4v']);
+// Single source of truth for which extensions route to a video source (used by
+// both local files and direct URLs). The extension only gates detection —
+// ffmpeg does the actual demuxing, so most common containers work. `.ts` is
+// intentionally excluded: it collides with the TypeScript source extension.
+const VIDEO_EXTENSIONS = new Set([
+  '.mp4',
+  '.webm',
+  '.mov',
+  '.avi',
+  '.mkv',
+  '.m4v',
+  '.wmv',
+  '.flv',
+  '.mpeg',
+  '.mpg',
+  '.m2ts',
+  '.mts',
+  '.3gp',
+  '.ogv',
+]);
 
 export function detectPlatform(url: string): Platform | null {
   if (!url) return null;

--- a/src/utils/url-detector.ts
+++ b/src/utils/url-detector.ts
@@ -1,11 +1,20 @@
+import { isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 const LOOM_PATTERN = /^https?:\/\/(?:www\.)?loom\.com\/(?:share|embed)\/([a-f0-9-]+)/i;
 
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mov', '.avi', '.mkv', '.m4v']);
 
-type Platform = 'loom' | 'direct';
+type Platform = 'loom' | 'direct' | 'local';
 
 export function detectPlatform(url: string): Platform | null {
   if (!url) return null;
+
+  const localPath = toLocalPath(url);
+  if (localPath !== null) {
+    const ext = getExtension(localPath);
+    return ext && VIDEO_EXTENSIONS.has(ext) ? 'local' : null;
+  }
 
   try {
     const parsed = new URL(url);
@@ -30,6 +39,39 @@ export function extractLoomId(url: string): string | null {
 
   const match = url.match(LOOM_PATTERN);
   return match ? match[1] : null;
+}
+
+/**
+ * Resolve a `file://` URI or absolute fs path to an absolute local path.
+ * Returns null for HTTP(S) URLs, relative paths, and anything else.
+ */
+export function toLocalPath(input: string): string | null {
+  if (!input) return null;
+
+  if (input.startsWith('file://')) {
+    try {
+      return fileURLToPath(input);
+    } catch {
+      return null;
+    }
+  }
+
+  if (isAbsolute(input)) {
+    return input;
+  }
+
+  return null;
+}
+
+/**
+ * True if the input is a supported video source: an http(s) URL we recognize,
+ * or an absolute local path / `file://` URI to a video file.
+ *
+ * Used by tool zod schemas. Relative paths are rejected — the MCP server's
+ * working directory is unpredictable from the client's perspective.
+ */
+export function isVideoSource(input: string): boolean {
+  return detectPlatform(input) !== null;
 }
 
 function getExtension(pathname: string): string | null {

--- a/src/utils/url-detector.ts
+++ b/src/utils/url-detector.ts
@@ -1,11 +1,10 @@
 import { isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Platform } from '../types.js';
 
 const LOOM_PATTERN = /^https?:\/\/(?:www\.)?loom\.com\/(?:share|embed)\/([a-f0-9-]+)/i;
 
 const VIDEO_EXTENSIONS = new Set(['.mp4', '.webm', '.mov', '.avi', '.mkv', '.m4v']);
-
-type Platform = 'loom' | 'direct' | 'local';
 
 export function detectPlatform(url: string): Platform | null {
   if (!url) return null;

--- a/test/e2e/analyze-local.e2e.test.ts
+++ b/test/e2e/analyze-local.e2e.test.ts
@@ -70,4 +70,19 @@ describe('E2E: Local file analysis', () => {
     expect(metadata.platform).toBe('local');
     expect(metadata.title).toBe('tiny.mp4');
   });
+
+  it('populates rich metadata via ffmpeg probe (duration, dims, codec, hasAudio)', async () => {
+    const adapter = getAdapter(TEST_LOCAL_VIDEO_PATH);
+    const metadata = await adapter.getMetadata(TEST_LOCAL_VIDEO_PATH);
+
+    expect(metadata.duration).toBeGreaterThan(2);
+    expect(metadata.duration).toBeLessThan(4);
+    expect(metadata.durationFormatted).toMatch(/^0:0[23]$/);
+    expect(metadata.width).toBe(320);
+    expect(metadata.height).toBe(240);
+    expect(metadata.fps).toBe(10);
+    expect(metadata.videoCodec).toBe('h264');
+    expect(metadata.hasAudio).toBe(false);
+    expect(metadata.fileSizeBytes).toBeGreaterThan(0);
+  });
 });

--- a/test/e2e/analyze-local.e2e.test.ts
+++ b/test/e2e/analyze-local.e2e.test.ts
@@ -1,0 +1,73 @@
+import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  clearAdapters,
+  getAdapter,
+  registerAdapter,
+} from '../../src/adapters/adapter.interface.js';
+import { LocalFileAdapter } from '../../src/adapters/local-file.adapter.js';
+import { extractFrameAt, probeVideoDuration } from '../../src/processors/frame-extractor.js';
+import { optimizeFrame } from '../../src/processors/image-optimizer.js';
+import { cleanupTempDir, createTempDir, getTempFilePath } from '../../src/utils/temp-files.js';
+import { TEST_LOCAL_VIDEO_PATH } from './fixtures.js';
+
+describe('E2E: Local file analysis', () => {
+  let tempDir: string;
+
+  beforeAll(async () => {
+    clearAdapters();
+    registerAdapter(new LocalFileAdapter());
+    tempDir = await createTempDir('e2e-local-');
+  });
+
+  afterAll(async () => {
+    clearAdapters();
+    if (tempDir) await cleanupTempDir(tempDir);
+  });
+
+  it('detects local adapter for an absolute path', () => {
+    const adapter = getAdapter(TEST_LOCAL_VIDEO_PATH);
+    expect(adapter.name).toBe('local');
+  });
+
+  it('detects local adapter for a file:// URI', () => {
+    const adapter = getAdapter(pathToFileURL(TEST_LOCAL_VIDEO_PATH).href);
+    expect(adapter.name).toBe('local');
+  });
+
+  it('downloadVideo returns the source path unchanged', async () => {
+    const adapter = getAdapter(TEST_LOCAL_VIDEO_PATH);
+    const videoPath = await adapter.downloadVideo(TEST_LOCAL_VIDEO_PATH, tempDir);
+
+    expect(videoPath).toBe(TEST_LOCAL_VIDEO_PATH);
+    expect(existsSync(videoPath as string)).toBe(true);
+  });
+
+  it('probes duration of the local file', async () => {
+    const duration = await probeVideoDuration(TEST_LOCAL_VIDEO_PATH);
+    expect(duration).toBeGreaterThan(0);
+  });
+
+  it('extracts a frame at a timestamp from the local file', async () => {
+    const frame = await extractFrameAt(TEST_LOCAL_VIDEO_PATH, tempDir, '0:01');
+    expect(existsSync(frame.filePath)).toBe(true);
+    expect(frame.mimeType).toBe('image/jpeg');
+  });
+
+  it('optimizes the extracted frame', async () => {
+    const frame = await extractFrameAt(TEST_LOCAL_VIDEO_PATH, tempDir, '0:02');
+    const optimizedPath = getTempFilePath(tempDir, 'opt_local.jpg');
+    await optimizeFrame(frame.filePath, optimizedPath);
+
+    expect(existsSync(optimizedPath)).toBe(true);
+  });
+
+  it('returns local-file metadata with basename as title', async () => {
+    const adapter = getAdapter(TEST_LOCAL_VIDEO_PATH);
+    const metadata = await adapter.getMetadata(TEST_LOCAL_VIDEO_PATH);
+
+    expect(metadata.platform).toBe('local');
+    expect(metadata.title).toBe('tiny.mp4');
+  });
+});

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -1,3 +1,6 @@
+import { join } from 'node:path';
+import { FIXTURES_DIR } from '../helpers/fixtures.js';
+
 /**
  * Shared test fixtures for E2E tests.
  *
@@ -8,3 +11,6 @@ export const TEST_LOOM_URL =
   process.env['LOOM_TEST_URL'] ?? 'https://www.loom.com/share/bdebdfe44b294225ac718bad241a94fe';
 
 export const TEST_DIRECT_VIDEO_URL = 'https://www.w3schools.com/html/mov_bbb.mp4';
+
+/** Absolute path to the bundled `tiny.mp4` fixture for local-file tests. */
+export const TEST_LOCAL_VIDEO_PATH = join(FIXTURES_DIR, 'tiny.mp4');


### PR DESCRIPTION
## Summary

Adds support for analyzing local video files alongside the existing Loom / direct-URL sources. A path or `file://` URI now flows through the same tool surface (`analyze_video`, `get_transcript`, `get_frame_at`, etc.) with no API changes for callers.

The feature is delivered in five focused commits:

1. **`LocalFileAdapter`** — new adapter implementing `IVideoAdapter`. Path/URI detection added to `url-detector`. No changes to `LoomAdapter` or `DirectAdapter`.
2. **ffmpeg metadata probe** — local files get codec/resolution/fps/duration via `ffprobe` (using the bundled `ffmpeg-static` binary). Silent videos are detected and Whisper transcription is skipped to avoid wasted work.
3. **Sidecar transcripts** — if a `.vtt` or `.srt` file sits next to the video (`clip.mp4` + `clip.vtt`), it's used as the transcript instead of running Whisper.
4. **Embedded subtitle extraction** — videos with embedded subtitle streams (mov_text, etc.) have them extracted via ffmpeg and used as the transcript.
5. **Cache-key correctness** — local-file cache keys now mix in `mtime` + `size`, so re-analysis is triggered when the file is edited in place. (URL-based caching is unchanged.)

## Why

Lots of useful videos never hit a public URL — screen recordings saved locally, downloaded clips, files received via Slack/email. Forcing users to upload them to Loom just to analyze them is friction. The four-tier transcript strategy (sidecar → embedded subs → Whisper → none) also makes analysis dramatically faster and cheaper for files that already ship with captions.

## Notes for the maintainer

- All changes are additive or local-file-scoped; the Loom and direct-URL paths are untouched.
- I followed the conventions in `CONTRIBUTING.md` (tests next to source, graceful degradation via `warnings[]`, no unused exports).
- Happy to squash into fewer commits if you'd prefer a tighter history.