### PR TITLE
feat: add opt-in TwelveLabs Pegasus adapter (transcript + AI summary for direct video URLs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ The biggest win is on the text-only paths: `get_transcript` and `get_metadata` n
 
 It's fully opt-in and non-breaking: when `TWELVELABS_API_KEY` is set the `TwelveLabsAdapter` handles direct video URLs (it registers the public URL with TwelveLabs — no upload); when it's unset, the `DirectAdapter` handles them exactly as before. Loom URLs are unaffected. Get a key at [playground.twelvelabs.io](https://playground.twelvelabs.io).
 
+### Transcription (Whisper fallback)
+
+When a source has no native transcript (no sidecar `.vtt`/`.srt`, no embedded subtitles), the audio track is transcribed with Whisper via a graceful fallback chain:
+
+1. **@huggingface/transformers** (JS-native, zero external deps) — optional dependency; model via `WHISPER_HF_MODEL`.
+2. **`whisper` CLI** — used when a `whisper` executable is found (`pip install -U openai-whisper`). Point `WHISPER_BIN` at the executable if it isn't on `PATH`. Model via `WHISPER_MODEL`, language via `WHISPER_LANGUAGE`. The bundled `ffmpeg-static` is put on the CLI's `PATH` automatically, so no system ffmpeg is required.
+3. **OpenAI Whisper API** — used when `OPENAI_API_KEY` is set.
+
+| Env var | Applies to | Default | Example |
+|---------|-----------|---------|---------|
+| `WHISPER_MODEL` | `whisper` CLI | `tiny` | `small`, `medium` |
+| `WHISPER_LANGUAGE` | `whisper` CLI | auto-detect | `pt`, `en`, `es` |
+| `WHISPER_BIN` | `whisper` CLI | `whisper` (on PATH) | `C:/.../Scripts/whisper.exe` |
+| `WHISPER_HF_MODEL` | HF transformers | `Xenova/whisper-tiny` | `Xenova/whisper-small` |
+| `OPENAI_API_KEY` | OpenAI API | — | `sk-…` |
+
+> The default `tiny` model is fast but weak for non-English audio. For Portuguese (or other non-English) sources, install the CLI and set `WHISPER_MODEL=small` (or `medium`) + `WHISPER_LANGUAGE=pt` for much better accuracy. `faster-whisper` / `whisper-ctranslate2` are drop-in speed upgrades that expose the same `whisper` CLI flags.
+>
+> **Windows note:** pip installs `whisper.exe` into the Python `Scripts/` dir, which is often **not** on the `PATH` that GUI-launched MCP clients inherit. If transcripts come back empty, set `WHISPER_BIN` to the full path of `whisper.exe`.
+
 ### Frame Extraction Strategies
 
 Frame extraction uses a two-strategy fallback chain — no single dependency is required:
@@ -292,7 +312,6 @@ src/
 │   └── get-frame-burst.ts      # N frames in a time range
 ├── adapters/                   # Source-specific logic
 │   ├── adapter.interface.ts    # IVideoAdapter interface + registry
-│   ├── loom.adapter.ts         # Loom: authless GraphQL
 │   ├── loom.adapter.ts         # Loom: authless GraphQL
 │   ├── local-file.adapter.ts   # Local files: absolute path or file:// URI
 │   ├── twelvelabs.adapter.ts   # TwelveLabs Pegasus: transcript + AI summary (opt-in)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 |----------|:----------:|:--------:|:--------:|:------:|:----:|
 | **Loom** | Yes | Yes | Yes | Yes | None |
 | **Direct URL** (.mp4, .webm) | No | Duration only | No | Yes | None |
+| **Direct URL + TwelveLabs** | Yes (Pegasus ASR) | Title only | No | Yes | `TWELVELABS_API_KEY` |
+
+### TwelveLabs Pegasus (optional)
+
+Set the `TWELVELABS_API_KEY` environment variable to analyze direct video URLs with [TwelveLabs](https://twelvelabs.io) **Pegasus**. Pegasus analyzes the video server-side (visuals **and** its own audio ASR) and returns a timestamped transcript plus an AI summary as text — capabilities the `DirectAdapter` can't provide (a raw `.mp4` URL has no transcript or summary on its own), and with **no Whisper key required**.
+
+The biggest win is on the text-only paths: `get_transcript` and `get_metadata` now return a real Pegasus transcript and summary for direct URLs — a few KB of text, no frame images, no per-frame token cost. `analyze_video` at `detail: "standard"`/`"detailed"` still extracts frames in addition (use `detail: "brief"` or `skipFrames: true` to stay text-only).
+
+It's fully opt-in and non-breaking: when `TWELVELABS_API_KEY` is set the `TwelveLabsAdapter` handles direct video URLs (it registers the public URL with TwelveLabs — no upload); when it's unset, the `DirectAdapter` handles them exactly as before. Loom URLs are unaffected. Get a key at [playground.twelvelabs.io](https://playground.twelvelabs.io).
 
 ### Frame Extraction Strategies
 
@@ -275,6 +284,7 @@ src/
 ├── adapters/                   # Platform-specific logic
 │   ├── adapter.interface.ts    # IVideoAdapter interface + registry
 │   ├── loom.adapter.ts         # Loom: authless GraphQL
+│   ├── twelvelabs.adapter.ts   # TwelveLabs Pegasus: transcript + AI summary (opt-in)
 │   └── direct.adapter.ts       # Direct URL: any mp4/webm link
 ├── processors/                 # Shared processing
 │   ├── frame-extractor.ts      # ffmpeg scene detection + dense + burst extraction

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 |--------|:----------:|:--------:|:--------:|:------:|:----:|
 | **Loom** | Yes | Yes | Yes | Yes | None |
 | **Direct URL** (.mp4, .mov, .mkv, .webm, …) | No | Duration only | No | Yes | None |
-| **Direct URL + TwelveLabs** | Yes (Pegasus ASR) | Title only | No | Yes | `TWELVELABS_API_KEY` |
+| **Direct URL + TwelveLabs** | Yes (Pegasus, best-effort) | Duration floor + title | No | Yes | `TWELVELABS_API_KEY` |
 | **Local file** (absolute path or `file://` URI) | Sidecar `.vtt`/`.srt` or Whisper fallback | Probed via ffmpeg (duration, dims, codec, audio presence) | No | Yes | None |
 
 > **Local files**: pass an absolute path (e.g., `/Users/you/clip.mp4`) or a `file://` URI as the `url` argument to any tool. Relative paths are rejected — the server's working directory is unpredictable from the MCP client. Note that any caller of the MCP server can ask it to read any file the server process has access to.
@@ -189,9 +189,13 @@ Results are cached in memory for 10 minutes. Subsequent calls with the same URL 
 
 ### TwelveLabs Pegasus (optional)
 
-Set the `TWELVELABS_API_KEY` environment variable to analyze direct video URLs with [TwelveLabs](https://twelvelabs.io) **Pegasus**. Pegasus analyzes the video server-side (visuals **and** its own audio ASR) and returns a timestamped transcript plus an AI summary as text — capabilities the `DirectAdapter` can't provide (a raw `.mp4` URL has no transcript or summary on its own), and with **no Whisper key required**.
+Set the `TWELVELABS_API_KEY` environment variable to analyze direct video URLs with [TwelveLabs](https://twelvelabs.io) **Pegasus**. Pegasus analyzes the video server-side (visuals **and** its own audio) and returns an **AI-generated, timestamped transcript** plus an AI summary as text — capabilities the `DirectAdapter` can't provide (a raw `.mp4` URL has no transcript or summary on its own), and with **no Whisper key required**.
 
-The biggest win is on the text-only paths: `get_transcript` and `get_metadata` now return a real Pegasus transcript and summary for direct URLs — a few KB of text, no frame images, no per-frame token cost. `analyze_video` at `detail: "standard"`/`"detailed"` still extracts frames in addition (use `detail: "brief"` to stay text-only).
+The transcript is best-effort LLM output, not a deterministic ASR dump: Pegasus is *prompted* to emit `[MM:SS] line` rows, and lines that don't match that shape are dropped, so wording and exact timestamps depend on the model's prompt adherence. Failures (bad key, timeout, API error) surface in the tool's `warnings[]` rather than silently returning an empty transcript.
+
+The biggest win is on the text-only paths: `get_transcript` and `get_metadata` return a Pegasus transcript and summary for direct URLs — a few KB of text, no frame images, no per-frame token cost. `analyze_video` at `detail: "standard"`/`"detailed"` still extracts frames in addition (use `detail: "brief"` to stay text-only).
+
+> **Long videos**: the summary and full transcript share a single capped completion (`max_tokens` = 16384), so for very long videos the transcript may be truncated. For multi-hour content, chunking by time window is the better approach.
 
 It's fully opt-in and non-breaking: when `TWELVELABS_API_KEY` is set the `TwelveLabsAdapter` handles direct video URLs (it registers the public URL with TwelveLabs — no upload); when it's unset, the `DirectAdapter` handles them exactly as before. Loom URLs are unaffected. Get a key at [playground.twelvelabs.io](https://playground.twelvelabs.io).
 

--- a/src/adapters/direct.adapter.ts
+++ b/src/adapters/direct.adapter.ts
@@ -1,7 +1,3 @@
-import { createWriteStream } from 'node:fs';
-import { join } from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import type {
   IAdapterCapabilities,
   IChapter,
@@ -10,21 +6,8 @@ import type {
   IVideoMetadata,
 } from '../types.js';
 import { detectPlatform } from '../utils/url-detector.js';
+import { downloadDirectVideo, getFilenameFromUrl } from '../utils/video-download.js';
 import type { IVideoAdapter } from './adapter.interface.js';
-
-function getFilenameFromUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.split('/');
-    const lastSegment = segments[segments.length - 1];
-    if (lastSegment && lastSegment.includes('.')) {
-      return lastSegment;
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return 'video.mp4';
-}
 
 export class DirectAdapter implements IVideoAdapter {
   readonly name = 'direct';
@@ -69,17 +52,6 @@ export class DirectAdapter implements IVideoAdapter {
   }
 
   async downloadVideo(url: string, destDir: string): Promise<string | null> {
-    const filename = getFilenameFromUrl(url);
-    const destPath = join(destDir, filename);
-
-    const response = await fetch(url);
-    if (!response.ok || !response.body) {
-      return null;
-    }
-
-    const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
-    await pipeline(nodeStream, createWriteStream(destPath));
-
-    return destPath;
+    return downloadDirectVideo(url, destDir);
   }
 }

--- a/src/adapters/twelvelabs.adapter.test.ts
+++ b/src/adapters/twelvelabs.adapter.test.ts
@@ -1,4 +1,6 @@
+import { existsSync, readFileSync } from 'node:fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanupTempDir, createTempDir } from '../utils/temp-files.js';
 import { TwelveLabsAdapter } from './twelvelabs.adapter.js';
 
 const DIRECT_URL = 'https://example.com/demo.mp4';
@@ -11,44 +13,64 @@ TRANSCRIPT:
 [0:12] Notice the total did not update.
 [1:03] That's the bug.`;
 
+interface MockResponse {
+  ok?: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}
+
 /**
- * Mock the TwelveLabs REST flow: POST /assets -> ready asset, POST
- * /analyze/tasks -> task id, GET /analyze/tasks/:id -> ready + result text.
+ * Configurable mock of the TwelveLabs REST flow. By default the asset goes
+ * `pending -> ready` (one poll) and the analyze task goes `pending -> ready`
+ * (one poll), so the polling loops actually run. Each `*Poll` array is consumed
+ * sequentially, holding on the last element.
  */
-function mockTwelveLabsFetch(analysisText = ANALYSIS_TEXT): ReturnType<typeof vi.fn> {
+function mockTwelveLabsFetch(
+  opts: {
+    assetPost?: MockResponse;
+    assetPolls?: MockResponse[];
+    taskPost?: MockResponse;
+    taskPolls?: MockResponse[];
+  } = {},
+): ReturnType<typeof vi.fn> {
+  const assetPost = opts.assetPost ?? { json: { _id: 'asset_1', status: 'pending' } };
+  const assetPolls = opts.assetPolls ?? [{ json: { status: 'ready' } }];
+  const taskPost = opts.taskPost ?? { json: { task_id: 'task_1', status: 'pending' } };
+  const taskPolls = opts.taskPolls ?? [
+    { json: { status: 'ready', result: { data: ANALYSIS_TEXT } } },
+  ];
+  let assetIdx = 0;
+  let taskIdx = 0;
+
+  const respond = (r: MockResponse): Promise<unknown> =>
+    Promise.resolve({
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: () => Promise.resolve(r.json ?? {}),
+      text: () => Promise.resolve(r.text ?? ''),
+    });
+  const next = (arr: MockResponse[], i: number): MockResponse => arr[Math.min(i, arr.length - 1)];
+
   return vi.fn().mockImplementation((input: string, init?: { method?: string }) => {
     const url = String(input);
     const method = init?.method ?? 'GET';
-
-    if (url.endsWith('/assets') && method === 'POST') {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ _id: 'asset_1', status: 'ready' }),
-      });
-    }
-    if (url.endsWith('/analyze/tasks') && method === 'POST') {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ task_id: 'task_1', status: 'pending' }),
-      });
-    }
-    if (url.includes('/analyze/tasks/task_1')) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ status: 'ready', result: { data: analysisText } }),
-      });
-    }
-    return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve('unexpected') });
+    if (url.endsWith('/assets') && method === 'POST') return respond(assetPost);
+    if (url.includes('/assets/')) return respond(next(assetPolls, assetIdx++));
+    if (url.endsWith('/analyze/tasks') && method === 'POST') return respond(taskPost);
+    if (url.includes('/analyze/tasks/')) return respond(next(taskPolls, taskIdx++));
+    return respond({ ok: false, status: 404, text: 'unexpected' });
   });
 }
 
 describe('TwelveLabsAdapter', () => {
+  // Tiny timing so the poll/timeout branches run without real 3s sleeps.
   let adapter: TwelveLabsAdapter;
   const originalFetch = globalThis.fetch;
   const originalKey = process.env.TWELVELABS_API_KEY;
 
   beforeEach(() => {
-    adapter = new TwelveLabsAdapter();
+    adapter = new TwelveLabsAdapter({ pollIntervalMs: 0, requestTimeoutMs: 1000 });
     process.env.TWELVELABS_API_KEY = 'tlk_test_key';
   });
 
@@ -60,8 +82,10 @@ describe('TwelveLabsAdapter', () => {
   });
 
   describe('canHandle', () => {
-    it('handles direct video URLs when the API key is set', () => {
+    it('handles direct video URLs (.mp4/.webm/.mov) when the API key is set', () => {
       expect(adapter.canHandle(DIRECT_URL)).toBe(true);
+      expect(adapter.canHandle('https://example.com/clip.webm')).toBe(true);
+      expect(adapter.canHandle('https://example.com/clip.mov')).toBe(true);
     });
 
     it('declines when the API key is not set (DirectAdapter takes over)', () => {
@@ -78,17 +102,8 @@ describe('TwelveLabsAdapter', () => {
     });
   });
 
-  describe('getMetadata', () => {
-    it('returns twelvelabs platform metadata derived from the URL', async () => {
-      const metadata = await adapter.getMetadata(DIRECT_URL);
-      expect(metadata.platform).toBe('twelvelabs');
-      expect(metadata.title).toBe('demo.mp4');
-      expect(metadata.url).toBe(DIRECT_URL);
-    });
-  });
-
   describe('getTranscript', () => {
-    it('parses Pegasus output into timestamped transcript entries', async () => {
+    it('parses Pegasus output into timestamped entries (exercises both poll loops)', async () => {
       globalThis.fetch = mockTwelveLabsFetch();
       const entries = await adapter.getTranscript(DIRECT_URL);
       expect(entries).toHaveLength(3);
@@ -97,12 +112,49 @@ describe('TwelveLabsAdapter', () => {
       expect(entries[2].time).toBe('1:03');
     });
 
-    it('returns [] when the API fails (graceful degradation)', async () => {
+    it('throws (not []) when the API fails, so the tool layer can surface the reason', async () => {
       globalThis.fetch = vi
         .fn()
-        .mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('err') });
+        .mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('bad key') });
+      await expect(adapter.getTranscript(DIRECT_URL)).rejects.toThrow(/401/);
+    });
+
+    it('parses HH:MM:SS timestamps', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [
+          { json: { status: 'ready', result: { data: 'TRANSCRIPT:\n[1:02:03] An hour in.' } } },
+        ],
+      });
       const entries = await adapter.getTranscript(DIRECT_URL);
-      expect(entries).toEqual([]);
+      expect(entries).toEqual([{ time: '1:02:03', text: 'An hour in.' }]);
+    });
+
+    it('treats the "(no spoken dialogue)" sentinel as an empty transcript', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [
+          {
+            json: {
+              status: 'ready',
+              result: { data: 'SUMMARY:\nSilent clip.\nTRANSCRIPT:\n[00:00] (no spoken dialogue)' },
+            },
+          },
+        ],
+      });
+      expect(await adapter.getTranscript(DIRECT_URL)).toEqual([]);
+    });
+
+    it('returns an empty transcript when there is no TRANSCRIPT marker', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [
+          {
+            json: {
+              status: 'ready',
+              result: { data: 'SUMMARY:\nJust a summary, no transcript section.' },
+            },
+          },
+        ],
+      });
+      expect(await adapter.getTranscript(DIRECT_URL)).toEqual([]);
     });
   });
 
@@ -114,17 +166,105 @@ describe('TwelveLabsAdapter', () => {
       expect(summary).not.toContain('TRANSCRIPT');
     });
 
-    it('returns null when the API fails', async () => {
+    it('throws when the API fails', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('err') });
+      await expect(adapter.getAiSummary(DIRECT_URL)).rejects.toThrow(/500/);
+    });
+
+    it('reads alternate result keys (e.g. { text })', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [
+          { json: { status: 'ready', result: { text: 'SUMMARY:\nFrom the text key.' } } },
+        ],
+      });
+      expect(await adapter.getAiSummary(DIRECT_URL)).toContain('From the text key');
+    });
+
+    it('throws on an unrecognized result shape instead of stringifying it', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [{ json: { status: 'ready', result: { unexpected_field: 'oops' } } }],
+      });
+      await expect(adapter.getAiSummary(DIRECT_URL)).rejects.toThrow(/no recognized text field/);
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('derives a duration floor from the last transcript timestamp', async () => {
+      globalThis.fetch = mockTwelveLabsFetch();
+      const metadata = await adapter.getMetadata(DIRECT_URL);
+      expect(metadata.platform).toBe('twelvelabs');
+      expect(metadata.title).toBe('demo.mp4');
+      expect(metadata.url).toBe(DIRECT_URL);
+      expect(metadata.duration).toBe(63); // last entry [1:03]
+      expect(metadata.durationFormatted).toBe('1:03');
+    });
+
+    it('reports duration 0 when there is no transcript', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [{ json: { status: 'ready', result: { data: 'SUMMARY:\nNo speech here.' } } }],
+      });
+      const metadata = await adapter.getMetadata(DIRECT_URL);
+      expect(metadata.duration).toBe(0);
+      expect(metadata.durationFormatted).toBe('0:00');
+    });
+
+    it('throws when analysis fails', async () => {
       globalThis.fetch = vi
         .fn()
         .mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('bad key') });
-      const summary = await adapter.getAiSummary(DIRECT_URL);
-      expect(summary).toBeNull();
+      await expect(adapter.getMetadata(DIRECT_URL)).rejects.toThrow(/401/);
+    });
+  });
+
+  describe('asset polling', () => {
+    it('throws when the asset reports failed', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({ assetPolls: [{ json: { status: 'failed' } }] });
+      await expect(adapter.getTranscript(DIRECT_URL)).rejects.toThrow(/asset .* processing failed/);
+    });
+
+    it('throws when the asset never becomes ready before the deadline', async () => {
+      adapter = new TwelveLabsAdapter({
+        pollIntervalMs: 1,
+        assetReadyTimeoutMs: 5,
+        requestTimeoutMs: 1000,
+      });
+      globalThis.fetch = mockTwelveLabsFetch({ assetPolls: [{ json: { status: 'pending' } }] });
+      await expect(adapter.getTranscript(DIRECT_URL)).rejects.toThrow(/not ready in time/);
+    });
+  });
+
+  describe('analyze polling', () => {
+    it('re-polls a pending task until it is ready', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({
+        taskPolls: [
+          { json: { status: 'pending' } },
+          { json: { status: 'ready', result: { data: ANALYSIS_TEXT } } },
+        ],
+      });
+      const entries = await adapter.getTranscript(DIRECT_URL);
+      expect(entries).toHaveLength(3);
+    });
+
+    it('throws when the analyze task reports failed', async () => {
+      globalThis.fetch = mockTwelveLabsFetch({ taskPolls: [{ json: { status: 'failed' } }] });
+      await expect(adapter.getTranscript(DIRECT_URL)).rejects.toThrow(/analyze task .* failed/);
+    });
+
+    it('throws when the analyze task never finishes before the deadline', async () => {
+      adapter = new TwelveLabsAdapter({
+        pollIntervalMs: 1,
+        analyzeTimeoutMs: 5,
+        requestTimeoutMs: 1000,
+      });
+      globalThis.fetch = mockTwelveLabsFetch({ taskPolls: [{ json: { status: 'pending' } }] });
+      await expect(adapter.getTranscript(DIRECT_URL)).rejects.toThrow(/timed out/);
     });
   });
 
   describe('analysis caching', () => {
-    it('runs a single analysis when transcript and summary are both requested', async () => {
+    it('runs a single analysis when transcript and summary are requested together', async () => {
       const fetchMock = mockTwelveLabsFetch();
       globalThis.fetch = fetchMock;
       const [entries, summary] = await Promise.all([
@@ -133,11 +273,21 @@ describe('TwelveLabsAdapter', () => {
       ]);
       expect(entries.length).toBe(3);
       expect(summary).toContain('checkout bug');
-      // One asset POST + one analyze POST + one task GET = 3 calls total, not 6.
       const assetPosts = fetchMock.mock.calls.filter((c) =>
         String(c[0]).endsWith('/assets'),
       ).length;
       expect(assetPosts).toBe(1);
+    });
+
+    it('re-analyzes once the in-flight entry has settled (eviction contract)', async () => {
+      const fetchMock = mockTwelveLabsFetch();
+      globalThis.fetch = fetchMock;
+      await adapter.getTranscript(DIRECT_URL);
+      await adapter.getTranscript(DIRECT_URL); // after the first settled -> new analysis
+      const assetPosts = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).endsWith('/assets'),
+      ).length;
+      expect(assetPosts).toBe(2);
     });
   });
 
@@ -145,6 +295,37 @@ describe('TwelveLabsAdapter', () => {
     it('returns empty arrays', async () => {
       expect(await adapter.getComments(DIRECT_URL)).toEqual([]);
       expect(await adapter.getChapters(DIRECT_URL)).toEqual([]);
+    });
+  });
+
+  describe('downloadVideo', () => {
+    it('streams the video to the destination directory', async () => {
+      const readableStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(Buffer.from('fake video content'));
+          controller.close();
+        },
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, body: readableStream });
+      const tempDir = await createTempDir();
+      try {
+        const result = await adapter.downloadVideo(DIRECT_URL, tempDir);
+        expect(result).not.toBeNull();
+        expect(existsSync(result as string)).toBe(true);
+        expect(readFileSync(result as string).toString()).toBe('fake video content');
+      } finally {
+        await cleanupTempDir(tempDir).catch(() => undefined);
+      }
+    });
+
+    it('returns null when the download response is not ok', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+      const tempDir = await createTempDir();
+      try {
+        expect(await adapter.downloadVideo(DIRECT_URL, tempDir)).toBeNull();
+      } finally {
+        await cleanupTempDir(tempDir).catch(() => undefined);
+      }
     });
   });
 });

--- a/src/adapters/twelvelabs.adapter.test.ts
+++ b/src/adapters/twelvelabs.adapter.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TwelveLabsAdapter } from './twelvelabs.adapter.js';
+
+const DIRECT_URL = 'https://example.com/demo.mp4';
+
+const ANALYSIS_TEXT = `SUMMARY:
+A short screencast demonstrating a checkout bug where the cart total fails to update.
+
+TRANSCRIPT:
+[0:05] Let me add this item to the cart.
+[0:12] Notice the total did not update.
+[1:03] That's the bug.`;
+
+/**
+ * Mock the TwelveLabs REST flow: POST /assets -> ready asset, POST
+ * /analyze/tasks -> task id, GET /analyze/tasks/:id -> ready + result text.
+ */
+function mockTwelveLabsFetch(analysisText = ANALYSIS_TEXT): ReturnType<typeof vi.fn> {
+  return vi.fn().mockImplementation((input: string, init?: { method?: string }) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+
+    if (url.endsWith('/assets') && method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ _id: 'asset_1', status: 'ready' }),
+      });
+    }
+    if (url.endsWith('/analyze/tasks') && method === 'POST') {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ task_id: 'task_1', status: 'pending' }),
+      });
+    }
+    if (url.includes('/analyze/tasks/task_1')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ status: 'ready', result: { data: analysisText } }),
+      });
+    }
+    return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve('unexpected') });
+  });
+}
+
+describe('TwelveLabsAdapter', () => {
+  let adapter: TwelveLabsAdapter;
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.TWELVELABS_API_KEY;
+
+  beforeEach(() => {
+    adapter = new TwelveLabsAdapter();
+    process.env.TWELVELABS_API_KEY = 'tlk_test_key';
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.TWELVELABS_API_KEY;
+    else process.env.TWELVELABS_API_KEY = originalKey;
+    vi.restoreAllMocks();
+  });
+
+  describe('canHandle', () => {
+    it('handles direct video URLs when the API key is set', () => {
+      expect(adapter.canHandle(DIRECT_URL)).toBe(true);
+    });
+
+    it('declines when the API key is not set (DirectAdapter takes over)', () => {
+      delete process.env.TWELVELABS_API_KEY;
+      expect(adapter.canHandle(DIRECT_URL)).toBe(false);
+    });
+
+    it('declines Loom URLs (handled by LoomAdapter)', () => {
+      expect(adapter.canHandle('https://www.loom.com/share/abc123')).toBe(false);
+    });
+
+    it('declines non-video URLs', () => {
+      expect(adapter.canHandle('https://example.com/page.html')).toBe(false);
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('returns twelvelabs platform metadata derived from the URL', async () => {
+      const metadata = await adapter.getMetadata(DIRECT_URL);
+      expect(metadata.platform).toBe('twelvelabs');
+      expect(metadata.title).toBe('demo.mp4');
+      expect(metadata.url).toBe(DIRECT_URL);
+    });
+  });
+
+  describe('getTranscript', () => {
+    it('parses Pegasus output into timestamped transcript entries', async () => {
+      globalThis.fetch = mockTwelveLabsFetch();
+      const entries = await adapter.getTranscript(DIRECT_URL);
+      expect(entries).toHaveLength(3);
+      expect(entries[0].time).toBe('0:05');
+      expect(entries[0].text).toContain('add this item to the cart');
+      expect(entries[2].time).toBe('1:03');
+    });
+
+    it('returns [] when the API fails (graceful degradation)', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500, text: () => Promise.resolve('err') });
+      const entries = await adapter.getTranscript(DIRECT_URL);
+      expect(entries).toEqual([]);
+    });
+  });
+
+  describe('getAiSummary', () => {
+    it('returns the Pegasus summary section', async () => {
+      globalThis.fetch = mockTwelveLabsFetch();
+      const summary = await adapter.getAiSummary(DIRECT_URL);
+      expect(summary).toContain('checkout bug');
+      expect(summary).not.toContain('TRANSCRIPT');
+    });
+
+    it('returns null when the API fails', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401, text: () => Promise.resolve('bad key') });
+      const summary = await adapter.getAiSummary(DIRECT_URL);
+      expect(summary).toBeNull();
+    });
+  });
+
+  describe('analysis caching', () => {
+    it('runs a single analysis when transcript and summary are both requested', async () => {
+      const fetchMock = mockTwelveLabsFetch();
+      globalThis.fetch = fetchMock;
+      const [entries, summary] = await Promise.all([
+        adapter.getTranscript(DIRECT_URL),
+        adapter.getAiSummary(DIRECT_URL),
+      ]);
+      expect(entries.length).toBe(3);
+      expect(summary).toContain('checkout bug');
+      // One asset POST + one analyze POST + one task GET = 3 calls total, not 6.
+      const assetPosts = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).endsWith('/assets'),
+      ).length;
+      expect(assetPosts).toBe(1);
+    });
+  });
+
+  describe('getComments / getChapters', () => {
+    it('returns empty arrays', async () => {
+      expect(await adapter.getComments(DIRECT_URL)).toEqual([]);
+      expect(await adapter.getChapters(DIRECT_URL)).toEqual([]);
+    });
+  });
+});

--- a/src/adapters/twelvelabs.adapter.ts
+++ b/src/adapters/twelvelabs.adapter.ts
@@ -1,0 +1,283 @@
+import { createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type {
+  IAdapterCapabilities,
+  IChapter,
+  ITranscriptEntry,
+  IVideoComment,
+  IVideoMetadata,
+} from '../types.js';
+import { detectPlatform } from '../utils/url-detector.js';
+import type { IVideoAdapter } from './adapter.interface.js';
+
+/**
+ * TwelveLabs Pegasus adapter.
+ *
+ * Where the Loom and direct adapters hand a transcript (or nothing) to the
+ * frame-processing pipeline, this adapter sends the video to TwelveLabs'
+ * Pegasus video-language model for on-the-fly analysis and gets back a
+ * timestamped transcript *and* an AI summary as text — the first adapter to
+ * provide `aiSummary`. No frames, no Whisper key (Pegasus does its own ASR).
+ *
+ * It is opt-in: it only handles direct video URLs, and only when
+ * `TWELVELABS_API_KEY` is set. When the key is absent the DirectAdapter handles
+ * the same URLs unchanged. Because these are public, direct video URLs, the
+ * adapter registers them with TwelveLabs by URL (no upload).
+ *
+ * Pure `fetch`/`FormData` (Node 18+) — no SDK dependency.
+ */
+
+const TL_API_BASE = 'https://api.twelvelabs.io/v1.3';
+const TL_MODEL = 'pegasus1.5';
+const TL_MAX_TOKENS = 8192;
+const POLL_INTERVAL_MS = 3000;
+const ASSET_READY_TIMEOUT_MS = 120_000;
+const ANALYZE_TIMEOUT_MS = 300_000;
+
+const ANALYSIS_PROMPT = `Watch this video and respond in EXACTLY this format, with no text before "SUMMARY:":
+
+SUMMARY:
+<2-4 sentence summary of what the video shows and what is said>
+
+TRANSCRIPT:
+[MM:SS] <a verbatim line of the spoken dialogue or narration>
+[MM:SS] <the next line>
+
+Rules: exactly one transcript line per [MM:SS] timestamp, in chronological order, transcribing the audio verbatim. Use MM:SS (or HH:MM:SS for videos over an hour) relative to the start of the video. If there is no speech, output "[00:00] (no spoken dialogue)".`;
+
+interface AnalysisResult {
+  summary: string;
+  transcript: ITranscriptEntry[];
+}
+
+function tlApiKey(): string | undefined {
+  const key = process.env.TWELVELABS_API_KEY;
+  return key && key.trim() ? key.trim() : undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getFilenameFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split('/');
+    const lastSegment = segments[segments.length - 1];
+    if (lastSegment && lastSegment.includes('.')) {
+      return lastSegment;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return 'video.mp4';
+}
+
+async function tlJson(
+  path: string,
+  key: string,
+  init?: RequestInit,
+): Promise<Record<string, unknown>> {
+  const response = await fetch(`${TL_API_BASE}${path}`, {
+    ...init,
+    headers: { 'x-api-key': key, ...(init?.headers ?? {}) },
+  });
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`TwelveLabs ${path} failed: HTTP ${response.status} ${body.slice(0, 300)}`);
+  }
+  return (await response.json()) as Record<string, unknown>;
+}
+
+function idOf(payload: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === 'string' && value) return value;
+  }
+  return null;
+}
+
+/** Register a public direct-video URL as a TwelveLabs asset and wait until ready. */
+async function registerUrlAsset(url: string, key: string): Promise<string> {
+  const form = new FormData();
+  form.append('method', 'url');
+  form.append('url', url);
+
+  const created = await tlJson('/assets', key, { method: 'POST', body: form });
+  const assetId = idOf(created, '_id', 'id', 'asset_id');
+  if (!assetId) {
+    throw new Error('TwelveLabs asset registration returned no id');
+  }
+
+  let status = String(created.status ?? '').toLowerCase();
+  const deadline = Date.now() + ASSET_READY_TIMEOUT_MS;
+  while (status !== 'ready') {
+    if (status === 'failed') throw new Error(`TwelveLabs asset ${assetId} processing failed`);
+    if (Date.now() > deadline) throw new Error(`TwelveLabs asset ${assetId} not ready in time`);
+    await sleep(POLL_INTERVAL_MS);
+    const info = await tlJson(`/assets/${assetId}`, key);
+    status = String(info.status ?? '').toLowerCase();
+  }
+  return assetId;
+}
+
+/** Run on-the-fly Pegasus analysis against an asset and return the generated text. */
+async function analyzeAsset(assetId: string, key: string): Promise<string> {
+  const created = await tlJson('/analyze/tasks', key, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      video: { type: 'asset_id', asset_id: assetId },
+      model_name: TL_MODEL,
+      prompt: ANALYSIS_PROMPT,
+      max_tokens: TL_MAX_TOKENS,
+    }),
+  });
+  const taskId = idOf(created, 'task_id', '_id', 'id');
+  if (!taskId) throw new Error('TwelveLabs analyze task returned no id');
+
+  const deadline = Date.now() + ANALYZE_TIMEOUT_MS;
+  for (;;) {
+    const info = await tlJson(`/analyze/tasks/${taskId}`, key);
+    const status = String(info.status ?? '').toLowerCase();
+    if (status === 'ready') return extractText(info.result);
+    if (status === 'failed') throw new Error(`TwelveLabs analyze task ${taskId} failed`);
+    if (Date.now() > deadline) throw new Error(`TwelveLabs analyze task ${taskId} timed out`);
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+function extractText(result: unknown): string {
+  if (typeof result === 'string') return result.trim();
+  if (result && typeof result === 'object') {
+    const record = result as Record<string, unknown>;
+    for (const key of ['data', 'text', 'analysis', 'summary', 'generated_text', 'output']) {
+      const value = record[key];
+      if (typeof value === 'string' && value.trim()) return value.trim();
+    }
+    return JSON.stringify(result);
+  }
+  return '';
+}
+
+function parseAnalysis(text: string): AnalysisResult {
+  const marker = text.match(/TRANSCRIPT:/i);
+  let summaryPart = text;
+  let transcriptPart = '';
+  if (marker?.index !== undefined) {
+    summaryPart = text.slice(0, marker.index);
+    transcriptPart = text.slice(marker.index + marker[0].length);
+  }
+  const summary = summaryPart.replace(/SUMMARY:/i, '').trim();
+  return { summary, transcript: parseTimestampedLines(transcriptPart) };
+}
+
+function parseTimestampedLines(text: string): ITranscriptEntry[] {
+  const entries: ITranscriptEntry[] = [];
+  const lineRe = /\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]\s*(.+)/;
+  for (const raw of text.split('\n')) {
+    const match = raw.match(lineRe);
+    if (!match) continue;
+    const lineText = match[4].trim();
+    if (!lineText) continue;
+    const time =
+      match[3] !== undefined
+        ? `${parseInt(match[1], 10)}:${match[2]}:${match[3]}`
+        : `${parseInt(match[1], 10)}:${match[2]}`;
+    entries.push({ time, text: lineText });
+  }
+  return entries;
+}
+
+export class TwelveLabsAdapter implements IVideoAdapter {
+  readonly name = 'twelvelabs';
+  readonly capabilities: IAdapterCapabilities = {
+    transcript: true,
+    metadata: true,
+    comments: false,
+    chapters: false,
+    aiSummary: true,
+    videoDownload: true,
+  };
+
+  // One Pegasus analysis serves both getTranscript and getAiSummary; cache the
+  // in-flight promise per URL so concurrent calls share a single API round-trip.
+  private readonly cache = new Map<string, Promise<AnalysisResult>>();
+
+  canHandle(url: string): boolean {
+    // Opt-in: only intercept direct video URLs, and only when a key is set, so
+    // the DirectAdapter remains the default whenever TwelveLabs isn't configured.
+    return Boolean(tlApiKey()) && detectPlatform(url) === 'direct';
+  }
+
+  async getMetadata(url: string): Promise<IVideoMetadata> {
+    const filename = getFilenameFromUrl(url);
+    return {
+      platform: 'twelvelabs',
+      title: filename,
+      duration: 0,
+      durationFormatted: '0:00',
+      url,
+    };
+  }
+
+  async getTranscript(url: string): Promise<ITranscriptEntry[]> {
+    try {
+      return (await this.analyze(url)).transcript;
+    } catch {
+      return [];
+    }
+  }
+
+  async getComments(_url: string): Promise<IVideoComment[]> {
+    return [];
+  }
+
+  async getChapters(_url: string): Promise<IChapter[]> {
+    return [];
+  }
+
+  async getAiSummary(url: string): Promise<string | null> {
+    try {
+      const { summary } = await this.analyze(url);
+      return summary || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async downloadVideo(url: string, destDir: string): Promise<string | null> {
+    // Same direct HTTP download as DirectAdapter, so frame-based tools still
+    // work alongside Pegasus analysis.
+    const destPath = join(destDir, getFilenameFromUrl(url));
+    const response = await fetch(url);
+    if (!response.ok || !response.body) return null;
+    const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+    await pipeline(nodeStream, createWriteStream(destPath));
+    return destPath;
+  }
+
+  private analyze(url: string): Promise<AnalysisResult> {
+    const cached = this.cache.get(url);
+    if (cached) return cached;
+    const pending = this.runAnalysis(url);
+    this.cache.set(url, pending);
+    // De-dupe only the in-flight request: getTranscript + getAiSummary called
+    // together share one round-trip, but the entry is evicted once it settles so
+    // later calls re-analyze (no stale results, defers freshness to the caller).
+    void pending.finally(() => {
+      if (this.cache.get(url) === pending) this.cache.delete(url);
+    });
+    return pending;
+  }
+
+  private async runAnalysis(url: string): Promise<AnalysisResult> {
+    const key = tlApiKey();
+    if (!key) throw new Error('TWELVELABS_API_KEY is not set');
+    const assetId = await registerUrlAsset(url, key);
+    const text = await analyzeAsset(assetId, key);
+    return parseAnalysis(text);
+  }
+}

--- a/src/adapters/twelvelabs.adapter.ts
+++ b/src/adapters/twelvelabs.adapter.ts
@@ -267,9 +267,13 @@ export class TwelveLabsAdapter implements IVideoAdapter {
     // De-dupe only the in-flight request: getTranscript + getAiSummary called
     // together share one round-trip, but the entry is evicted once it settles so
     // later calls re-analyze (no stale results, defers freshness to the caller).
-    void pending.finally(() => {
+    // `then(evict, evict)` (not `finally`) keeps this bookkeeping from surfacing
+    // as an unhandled rejection — consumers await `pending` directly and handle
+    // failures (getTranscript → [], getAiSummary → null) themselves.
+    const evict = (): void => {
       if (this.cache.get(url) === pending) this.cache.delete(url);
-    });
+    };
+    void pending.then(evict, evict);
     return pending;
   }
 

--- a/src/adapters/twelvelabs.adapter.ts
+++ b/src/adapters/twelvelabs.adapter.ts
@@ -1,7 +1,3 @@
-import { createWriteStream } from 'node:fs';
-import { join } from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import type {
   IAdapterCapabilities,
   IChapter,
@@ -10,6 +6,7 @@ import type {
   IVideoMetadata,
 } from '../types.js';
 import { detectPlatform } from '../utils/url-detector.js';
+import { downloadDirectVideo, getFilenameFromUrl } from '../utils/video-download.js';
 import type { IVideoAdapter } from './adapter.interface.js';
 
 /**
@@ -17,24 +14,40 @@ import type { IVideoAdapter } from './adapter.interface.js';
  *
  * Where the Loom and direct adapters hand a transcript (or nothing) to the
  * frame-processing pipeline, this adapter sends the video to TwelveLabs'
- * Pegasus video-language model for on-the-fly analysis and gets back a
- * timestamped transcript *and* an AI summary as text — the first adapter to
- * provide `aiSummary`. No frames, no Whisper key (Pegasus does its own ASR).
+ * Pegasus video-language model for on-the-fly analysis and gets back an
+ * AI-generated, timestamped transcript *and* a summary as text — the first
+ * adapter to provide `aiSummary`. No frames, no Whisper key (Pegasus does its
+ * own ASR). The transcript is best-effort LLM output: Pegasus is prompted to
+ * emit `[MM:SS] line` rows, so its formatting/verbatimness depends on prompt
+ * adherence rather than being a deterministic ASR dump.
  *
  * It is opt-in: it only handles direct video URLs, and only when
  * `TWELVELABS_API_KEY` is set. When the key is absent the DirectAdapter handles
  * the same URLs unchanged. Because these are public, direct video URLs, the
  * adapter registers them with TwelveLabs by URL (no upload).
  *
+ * Failures (bad key, 5xx, asset/analyze `failed`, timeouts) propagate out of
+ * `getTranscript`/`getAiSummary`/`getMetadata` so the tool layer records the
+ * reason in `warnings[]` — they are not swallowed into empty results.
+ *
  * Pure `fetch`/`FormData` (Node 18+) — no SDK dependency.
  */
 
 const TL_API_BASE = 'https://api.twelvelabs.io/v1.3';
 const TL_MODEL = 'pegasus1.5';
-const TL_MAX_TOKENS = 8192;
-const POLL_INTERVAL_MS = 3000;
-const ASSET_READY_TIMEOUT_MS = 120_000;
-const ANALYZE_TIMEOUT_MS = 300_000;
+// One completion holds both the summary and the full transcript, so give it
+// generous headroom. Very long videos can still exceed this; see the README.
+const TL_MAX_TOKENS = 16_384;
+
+const DEFAULT_POLL_INTERVAL_MS = 3000;
+const DEFAULT_ASSET_READY_TIMEOUT_MS = 120_000;
+const DEFAULT_ANALYZE_TIMEOUT_MS = 300_000;
+// Per-request hard timeout. Without it, a single hung fetch would never settle
+// and the wall-clock poll deadlines below (which only run *between* responses)
+// could never fire.
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
+const NO_DIALOGUE_SENTINEL = /^\(no spoken dialogue\)$/i;
 
 const ANALYSIS_PROMPT = `Watch this video and respond in EXACTLY this format, with no text before "SUMMARY:":
 
@@ -52,6 +65,14 @@ interface AnalysisResult {
   transcript: ITranscriptEntry[];
 }
 
+/** Optional timing overrides — mainly so tests can exercise the poll/timeout branches without real sleeps. */
+interface TwelveLabsAdapterOptions {
+  pollIntervalMs?: number;
+  assetReadyTimeoutMs?: number;
+  analyzeTimeoutMs?: number;
+  requestTimeoutMs?: number;
+}
+
 function tlApiKey(): string | undefined {
   const key = process.env.TWELVELABS_API_KEY;
   return key && key.trim() ? key.trim() : undefined;
@@ -59,36 +80,6 @@ function tlApiKey(): string | undefined {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function getFilenameFromUrl(url: string): string {
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.split('/');
-    const lastSegment = segments[segments.length - 1];
-    if (lastSegment && lastSegment.includes('.')) {
-      return lastSegment;
-    }
-  } catch {
-    // ignore parse errors
-  }
-  return 'video.mp4';
-}
-
-async function tlJson(
-  path: string,
-  key: string,
-  init?: RequestInit,
-): Promise<Record<string, unknown>> {
-  const response = await fetch(`${TL_API_BASE}${path}`, {
-    ...init,
-    headers: { 'x-api-key': key, ...(init?.headers ?? {}) },
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`TwelveLabs ${path} failed: HTTP ${response.status} ${body.slice(0, 300)}`);
-  }
-  return (await response.json()) as Record<string, unknown>;
 }
 
 function idOf(payload: Record<string, unknown>, ...keys: string[]): string | null {
@@ -99,54 +90,11 @@ function idOf(payload: Record<string, unknown>, ...keys: string[]): string | nul
   return null;
 }
 
-/** Register a public direct-video URL as a TwelveLabs asset and wait until ready. */
-async function registerUrlAsset(url: string, key: string): Promise<string> {
-  const form = new FormData();
-  form.append('method', 'url');
-  form.append('url', url);
-
-  const created = await tlJson('/assets', key, { method: 'POST', body: form });
-  const assetId = idOf(created, '_id', 'id', 'asset_id');
-  if (!assetId) {
-    throw new Error('TwelveLabs asset registration returned no id');
-  }
-
-  let status = String(created.status ?? '').toLowerCase();
-  const deadline = Date.now() + ASSET_READY_TIMEOUT_MS;
-  while (status !== 'ready') {
-    if (status === 'failed') throw new Error(`TwelveLabs asset ${assetId} processing failed`);
-    if (Date.now() > deadline) throw new Error(`TwelveLabs asset ${assetId} not ready in time`);
-    await sleep(POLL_INTERVAL_MS);
-    const info = await tlJson(`/assets/${assetId}`, key);
-    status = String(info.status ?? '').toLowerCase();
-  }
-  return assetId;
-}
-
-/** Run on-the-fly Pegasus analysis against an asset and return the generated text. */
-async function analyzeAsset(assetId: string, key: string): Promise<string> {
-  const created = await tlJson('/analyze/tasks', key, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      video: { type: 'asset_id', asset_id: assetId },
-      model_name: TL_MODEL,
-      prompt: ANALYSIS_PROMPT,
-      max_tokens: TL_MAX_TOKENS,
-    }),
-  });
-  const taskId = idOf(created, 'task_id', '_id', 'id');
-  if (!taskId) throw new Error('TwelveLabs analyze task returned no id');
-
-  const deadline = Date.now() + ANALYZE_TIMEOUT_MS;
-  for (;;) {
-    const info = await tlJson(`/analyze/tasks/${taskId}`, key);
-    const status = String(info.status ?? '').toLowerCase();
-    if (status === 'ready') return extractText(info.result);
-    if (status === 'failed') throw new Error(`TwelveLabs analyze task ${taskId} failed`);
-    if (Date.now() > deadline) throw new Error(`TwelveLabs analyze task ${taskId} timed out`);
-    await sleep(POLL_INTERVAL_MS);
-  }
+/** Parse an "M:SS" / "MM:SS" / "H:MM:SS" timestamp into seconds (0 if unparseable). */
+function timestampToSeconds(time: string): number {
+  const parts = time.split(':').map((p) => Number.parseInt(p, 10));
+  if (parts.length === 0 || parts.some((n) => Number.isNaN(n))) return 0;
+  return parts.reduce((acc, n) => acc * 60 + n, 0);
 }
 
 function extractText(result: unknown): string {
@@ -157,9 +105,33 @@ function extractText(result: unknown): string {
       const value = record[key];
       if (typeof value === 'string' && value.trim()) return value.trim();
     }
-    return JSON.stringify(result);
+    // An unrecognized object shape (e.g. a changed result schema) must NOT be
+    // stringified into a fake summary — surface it as a failure instead.
+    throw new Error(
+      `TwelveLabs analyze result had no recognized text field; keys: ${Object.keys(record).join(', ')}`,
+    );
   }
-  return '';
+  throw new Error('TwelveLabs analyze result contained no text');
+}
+
+function parseTimestampedLines(text: string): ITranscriptEntry[] {
+  const entries: ITranscriptEntry[] = [];
+  const lineRe = /\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]\s*(.+)/;
+  for (const raw of text.split('\n')) {
+    const match = raw.match(lineRe);
+    if (!match) continue;
+    const lineText = match[4].trim();
+    if (!lineText) continue;
+    // The prompt asks Pegasus to emit "[00:00] (no spoken dialogue)" for silent
+    // videos; treat that sentinel as an empty transcript, not a one-line one.
+    if (NO_DIALOGUE_SENTINEL.test(lineText)) continue;
+    const time =
+      match[3] !== undefined
+        ? `${Number.parseInt(match[1], 10)}:${match[2]}:${match[3]}`
+        : `${Number.parseInt(match[1], 10)}:${match[2]}`;
+    entries.push({ time, text: lineText });
+  }
+  return entries;
 }
 
 function parseAnalysis(text: string): AnalysisResult {
@@ -174,23 +146,6 @@ function parseAnalysis(text: string): AnalysisResult {
   return { summary, transcript: parseTimestampedLines(transcriptPart) };
 }
 
-function parseTimestampedLines(text: string): ITranscriptEntry[] {
-  const entries: ITranscriptEntry[] = [];
-  const lineRe = /\[(\d{1,2}):(\d{2})(?::(\d{2}))?\]\s*(.+)/;
-  for (const raw of text.split('\n')) {
-    const match = raw.match(lineRe);
-    if (!match) continue;
-    const lineText = match[4].trim();
-    if (!lineText) continue;
-    const time =
-      match[3] !== undefined
-        ? `${parseInt(match[1], 10)}:${match[2]}:${match[3]}`
-        : `${parseInt(match[1], 10)}:${match[2]}`;
-    entries.push({ time, text: lineText });
-  }
-  return entries;
-}
-
 export class TwelveLabsAdapter implements IVideoAdapter {
   readonly name = 'twelvelabs';
   readonly capabilities: IAdapterCapabilities = {
@@ -202,9 +157,21 @@ export class TwelveLabsAdapter implements IVideoAdapter {
     videoDownload: true,
   };
 
-  // One Pegasus analysis serves both getTranscript and getAiSummary; cache the
-  // in-flight promise per URL so concurrent calls share a single API round-trip.
+  private readonly pollIntervalMs: number;
+  private readonly assetReadyTimeoutMs: number;
+  private readonly analyzeTimeoutMs: number;
+  private readonly requestTimeoutMs: number;
+
+  // One Pegasus analysis serves getMetadata + getTranscript + getAiSummary; cache
+  // the in-flight promise per URL so concurrent calls share a single API round-trip.
   private readonly cache = new Map<string, Promise<AnalysisResult>>();
+
+  constructor(options: TwelveLabsAdapterOptions = {}) {
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.assetReadyTimeoutMs = options.assetReadyTimeoutMs ?? DEFAULT_ASSET_READY_TIMEOUT_MS;
+    this.analyzeTimeoutMs = options.analyzeTimeoutMs ?? DEFAULT_ANALYZE_TIMEOUT_MS;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
 
   canHandle(url: string): boolean {
     // Opt-in: only intercept direct video URLs, and only when a key is set, so
@@ -213,22 +180,28 @@ export class TwelveLabsAdapter implements IVideoAdapter {
   }
 
   async getMetadata(url: string): Promise<IVideoMetadata> {
-    const filename = getFilenameFromUrl(url);
-    return {
+    const metadata: IVideoMetadata = {
       platform: 'twelvelabs',
-      title: filename,
+      title: getFilenameFromUrl(url),
       duration: 0,
       durationFormatted: '0:00',
       url,
     };
+    // Pegasus returns no duration field, but the last transcript timestamp is a
+    // lower bound — far better than asserting 0:00. Reuses the cached analysis,
+    // so analyze_video still makes a single Pegasus call across all three getters.
+    // Errors propagate; the tool layer records them in warnings[].
+    const { transcript } = await this.analyze(url);
+    const last = transcript[transcript.length - 1];
+    if (last) {
+      metadata.duration = timestampToSeconds(last.time);
+      metadata.durationFormatted = last.time;
+    }
+    return metadata;
   }
 
   async getTranscript(url: string): Promise<ITranscriptEntry[]> {
-    try {
-      return (await this.analyze(url)).transcript;
-    } catch {
-      return [];
-    }
+    return (await this.analyze(url)).transcript;
   }
 
   async getComments(_url: string): Promise<IVideoComment[]> {
@@ -240,23 +213,14 @@ export class TwelveLabsAdapter implements IVideoAdapter {
   }
 
   async getAiSummary(url: string): Promise<string | null> {
-    try {
-      const { summary } = await this.analyze(url);
-      return summary || null;
-    } catch {
-      return null;
-    }
+    const { summary } = await this.analyze(url);
+    return summary || null;
   }
 
   async downloadVideo(url: string, destDir: string): Promise<string | null> {
     // Same direct HTTP download as DirectAdapter, so frame-based tools still
     // work alongside Pegasus analysis.
-    const destPath = join(destDir, getFilenameFromUrl(url));
-    const response = await fetch(url);
-    if (!response.ok || !response.body) return null;
-    const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
-    await pipeline(nodeStream, createWriteStream(destPath));
-    return destPath;
+    return downloadDirectVideo(url, destDir);
   }
 
   private analyze(url: string): Promise<AnalysisResult> {
@@ -264,12 +228,11 @@ export class TwelveLabsAdapter implements IVideoAdapter {
     if (cached) return cached;
     const pending = this.runAnalysis(url);
     this.cache.set(url, pending);
-    // De-dupe only the in-flight request: getTranscript + getAiSummary called
-    // together share one round-trip, but the entry is evicted once it settles so
-    // later calls re-analyze (no stale results, defers freshness to the caller).
+    // De-dupe only the in-flight request: the three getters called together share
+    // one round-trip, but the entry is evicted once it settles so later calls
+    // re-analyze (no stale results, defers freshness to the caller).
     // `then(evict, evict)` (not `finally`) keeps this bookkeeping from surfacing
-    // as an unhandled rejection — consumers await `pending` directly and handle
-    // failures (getTranscript → [], getAiSummary → null) themselves.
+    // as an unhandled rejection — consumers await `pending` directly.
     const evict = (): void => {
       if (this.cache.get(url) === pending) this.cache.delete(url);
     };
@@ -280,8 +243,86 @@ export class TwelveLabsAdapter implements IVideoAdapter {
   private async runAnalysis(url: string): Promise<AnalysisResult> {
     const key = tlApiKey();
     if (!key) throw new Error('TWELVELABS_API_KEY is not set');
-    const assetId = await registerUrlAsset(url, key);
-    const text = await analyzeAsset(assetId, key);
+    const assetId = await this.registerUrlAsset(url, key);
+    const text = await this.analyzeAsset(assetId, key);
     return parseAnalysis(text);
+  }
+
+  private async tlJson(
+    path: string,
+    key: string,
+    init?: RequestInit,
+  ): Promise<Record<string, unknown>> {
+    // Hard per-request timeout via AbortController; clearTimeout in `finally` so
+    // the timer never dangles once the request settles (e.g. under test).
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(new Error(`request timed out after ${this.requestTimeoutMs}ms`)),
+      this.requestTimeoutMs,
+    );
+    try {
+      const response = await fetch(`${TL_API_BASE}${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: { 'x-api-key': key, ...(init?.headers ?? {}) },
+      });
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`TwelveLabs ${path} failed: HTTP ${response.status} ${body.slice(0, 300)}`);
+      }
+      return (await response.json()) as Record<string, unknown>;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /** Register a public direct-video URL as a TwelveLabs asset and wait until ready. */
+  private async registerUrlAsset(url: string, key: string): Promise<string> {
+    const form = new FormData();
+    form.append('method', 'url');
+    form.append('url', url);
+
+    const created = await this.tlJson('/assets', key, { method: 'POST', body: form });
+    const assetId = idOf(created, '_id', 'id', 'asset_id');
+    if (!assetId) {
+      throw new Error('TwelveLabs asset registration returned no id');
+    }
+
+    let status = String(created.status ?? '').toLowerCase();
+    const deadline = Date.now() + this.assetReadyTimeoutMs;
+    while (status !== 'ready') {
+      if (status === 'failed') throw new Error(`TwelveLabs asset ${assetId} processing failed`);
+      if (Date.now() > deadline) throw new Error(`TwelveLabs asset ${assetId} not ready in time`);
+      await sleep(this.pollIntervalMs);
+      const info = await this.tlJson(`/assets/${assetId}`, key);
+      status = String(info.status ?? '').toLowerCase();
+    }
+    return assetId;
+  }
+
+  /** Run on-the-fly Pegasus analysis against an asset and return the generated text. */
+  private async analyzeAsset(assetId: string, key: string): Promise<string> {
+    const created = await this.tlJson('/analyze/tasks', key, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        video: { type: 'asset_id', asset_id: assetId },
+        model_name: TL_MODEL,
+        prompt: ANALYSIS_PROMPT,
+        max_tokens: TL_MAX_TOKENS,
+      }),
+    });
+    const taskId = idOf(created, 'task_id', '_id', 'id');
+    if (!taskId) throw new Error('TwelveLabs analyze task returned no id');
+
+    const deadline = Date.now() + this.analyzeTimeoutMs;
+    for (;;) {
+      const info = await this.tlJson(`/analyze/tasks/${taskId}`, key);
+      const status = String(info.status ?? '').toLowerCase();
+      if (status === 'ready') return extractText(info.result);
+      if (status === 'failed') throw new Error(`TwelveLabs analyze task ${taskId} failed`);
+      if (Date.now() > deadline) throw new Error(`TwelveLabs analyze task ${taskId} timed out`);
+      await sleep(this.pollIntervalMs);
+    }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import { FastMCP } from 'fastmcp';
 import { registerAdapter } from './adapters/adapter.interface.js';
 import { DirectAdapter } from './adapters/direct.adapter.js';
 import { LoomAdapter } from './adapters/loom.adapter.js';
+import { TwelveLabsAdapter } from './adapters/twelvelabs.adapter.js';
 import { registerAnalyzeMoment } from './tools/analyze-moment.js';
 import { registerAnalyzeVideo } from './tools/analyze-video.js';
 import { registerGetFrameAt } from './tools/get-frame-at.js';
@@ -28,7 +29,7 @@ The AI should ALWAYS call the appropriate tool automatically — never ask "woul
 
 Supported platforms:
 - Loom (loom.com/share/...) — transcript, metadata, comments, frames (no auth needed)
-- Direct video URLs (.mp4, .webm, .mov) — frame extraction, duration probing
+- Direct video URLs (.mp4, .webm, .mov) — frame extraction, duration probing. When TWELVELABS_API_KEY is set, TwelveLabs Pegasus also provides a timestamped transcript + AI summary for these (which direct URLs otherwise lack); prefer get_transcript for a text-only, no-frames answer.
 
 Tools (choose the most efficient one for the task):
 - analyze_video: Full analysis. Use by default when a video URL appears. Returns transcript + frames + metadata + OCR + timeline.
@@ -53,8 +54,12 @@ Decision flow:
 6. User asks to see motion/animation → get_frame_burst`,
   });
 
-  // Register adapters (order matters: more specific first)
+  // Register adapters (order matters: more specific first).
+  // TwelveLabsAdapter precedes DirectAdapter: when TWELVELABS_API_KEY is set it
+  // takes over direct video URLs (Pegasus transcript + AI summary); otherwise
+  // it declines and DirectAdapter handles them as before.
   registerAdapter(new LoomAdapter());
+  registerAdapter(new TwelveLabsAdapter());
   registerAdapter(new DirectAdapter());
 
   // Register tools

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ The AI should ALWAYS call the appropriate tool automatically — never ask "woul
 
 Supported sources:
 - Loom (loom.com/share/...) — transcript, metadata, comments, frames (no auth needed)
-- Direct video URLs (.mp4, .webm, .mov) — frame extraction, duration probing. When TWELVELABS_API_KEY is set, TwelveLabs Pegasus also provides a timestamped transcript + AI summary for these (which direct URLs otherwise lack); prefer get_transcript for a text-only, no-frames answer.
+- Direct video URLs (.mp4, .webm, .mov) — frame extraction, duration probing. When TWELVELABS_API_KEY is set, TwelveLabs Pegasus also provides an AI-generated, timestamped transcript (best-effort, not deterministic ASR) + AI summary for these (which direct URLs otherwise lack); prefer get_transcript for a text-only, no-frames answer.
 - Local video files — pass an absolute path (e.g., "/Users/you/clip.mp4") or a file:// URI; frame extraction + Whisper transcription work the same way
 
 Tools (choose the most efficient one for the task):

--- a/src/tools/analyze-video.ts
+++ b/src/tools/analyze-video.ts
@@ -215,7 +215,12 @@ Use options.forceRefresh to bypass the cache.`,
             return [];
           }),
           adapter.getChapters(url).catch(() => []),
-          adapter.getAiSummary(url).catch(() => null),
+          adapter.getAiSummary(url).catch((e: unknown) => {
+            warnings.push(
+              `Failed to fetch AI summary: ${e instanceof Error ? e.message : String(e)}`,
+            );
+            return null;
+          }),
         ]);
 
         await progress(35, 'Metadata and transcript fetched');

--- a/src/tools/get-metadata.ts
+++ b/src/tools/get-metadata.ts
@@ -66,7 +66,12 @@ Supports: Loom (loom.com/share/...), direct video URLs (.mp4, .webm, .mov), and 
           return [];
         }),
         adapter.getChapters(url).catch(() => []),
-        adapter.getAiSummary(url).catch(() => null),
+        adapter.getAiSummary(url).catch((e: unknown) => {
+          warnings.push(
+            `Failed to fetch AI summary: ${e instanceof Error ? e.message : String(e)}`,
+          );
+          return null;
+        }),
       ]);
 
       await progress(100, 'Metadata fetched');

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ export interface ITranscriptEntry {
 }
 
 export interface IVideoMetadata {
-  platform: 'loom' | 'direct' | 'unknown';
+  platform: 'loom' | 'direct' | 'twelvelabs' | 'unknown';
   title: string;
   description?: string;
   duration: number;

--- a/src/utils/video-download.ts
+++ b/src/utils/video-download.ts
@@ -1,0 +1,41 @@
+import { createWriteStream } from 'node:fs';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+/**
+ * Best-effort filename for a direct video URL, falling back to `video.mp4`
+ * when the URL has no usable last path segment.
+ */
+export function getFilenameFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split('/');
+    const lastSegment = segments[segments.length - 1];
+    if (lastSegment && lastSegment.includes('.')) {
+      return lastSegment;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return 'video.mp4';
+}
+
+/**
+ * Stream a direct video URL to `destDir` and return the written path, or `null`
+ * if the response isn't OK / has no body. Shared by the Direct and TwelveLabs
+ * adapters so frame-based tools work the same way for any direct URL.
+ */
+export async function downloadDirectVideo(url: string, destDir: string): Promise<string | null> {
+  const destPath = join(destDir, getFilenameFromUrl(url));
+
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    return null;
+  }
+
+  const nodeStream = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+  await pipeline(nodeStream, createWriteStream(destPath));
+
+  return destPath;
+}


### PR DESCRIPTION
## Description

Hi! I'm Mohit, and I work @ TwelveLabs.

This PR adds a `TwelveLabsAdapter` that analyzes direct video URLs with [TwelveLabs](https://twelvelabs.io) **Pegasus**, providing a **timestamped transcript and AI summary** — capabilities that a raw `.mp4` or `.webm` URL otherwise does not have.

Pegasus analyzes the video server-side, including visuals and its own audio ASR, so `getTranscript` and `getMetadata` return a few KB of text without frame images and without requiring a Whisper key.

## Opt-in and non-breaking

This adapter only handles direct video URLs, and only when `TWELVELABS_API_KEY` is set.

It is registered before `DirectAdapter`, so when configured it takes over supported direct video URLs. Otherwise, `DirectAdapter` handles them unchanged. Loom URLs are untouched.

Verified behavior: `canHandle` returns `false` when no API key is present, and this is covered by a test.

## How it works

The adapter registers the public URL with TwelveLabs using `method=url`, so no upload is required. It then runs an async analyze task, polls for completion, and parses the result into transcript entries plus a summary.

Implementation details:

- Uses pure `fetch` / `FormData` on Node 18+
- No TwelveLabs SDK dependency
- One Pegasus call serves both `getTranscript` and `getAiSummary`
- In-flight requests are de-duped
- Gracefully degrades to `[]` / `null` on API failure, matching the repo's convention

## Tests and quality

This PR adds `twelvelabs.adapter.ts` plus 11 unit tests covering:

- `canHandle` gating
- asset registration → analyze → parse flow
- caching
- graceful degradation

Quality checks are clean:

- `tsc`
- `eslint`
- `knip`

I also live-verified the adapter end-to-end against the real TwelveLabs API. Pegasus correctly transcribed and summarized a public test video.

## Usage

Set `TWELVELABS_API_KEY` to enable the adapter.

You can get a key from [playground.twelvelabs.io](https://playground.twelvelabs.io).

Happy to adjust this to your preferences. Thanks for the clean adapter architecture — it made this a small change.