### PR TITLE
Self-building Docker image — fixes Glama CI build failure (v0.6.1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-src
+dist
 test
 scripts
 examples
@@ -7,8 +7,8 @@ examples
 .github
 *.md
 *.config.*
-tsconfig*.json
 .prettierrc
 knip.json
 glama.json
 smithery.yaml
+tsconfig.eslint.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,17 +61,19 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 2. **Run checks**: `npm run check` (format, lint, typecheck, knip, tests).
 3. **Run smoke test**: `npm run test:smoke` (verifies MCP server starts and responds).
 4. **Run package verification**: `npm run verify-package` (packs tarball, installs in temp dir, verifies startup).
-5. **Commit & push**: commit version bump to main.
-6. **Publish to npm**: `npm publish`.
-7. **Create GitHub release**: `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`.
-8. **Update .mcp.json**: pin new version in local MCP config.
-9. **Verify on npm**: `npm view mcp-video-analyzer version`.
+5. **Validate the Docker image from a clean clone** (Glama CI builds it from git on every release — `dist/` is gitignored, so the image must compile itself): `git archive HEAD -o sim.tar` → extract to an empty dir → `docker build` there → send an MCP `initialize` to `docker run -i` and expect a response. A build that only works with a locally pre-built `dist/` WILL fail on Glama and email the maintainer.
+6. **Commit & push**: commit version bump to main.
+7. **Publish to npm**: `npm publish`.
+8. **Create GitHub release**: `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`.
+9. **Update .mcp.json**: pin new version in local MCP config.
+10. **Verify on npm**: `npm view mcp-video-analyzer version`.
 
 ### Notes
 
 - Source maps are disabled in tsconfig to reduce package size.
 - `npm publish` runs `prepublishOnly` which executes `npm run check && npm run build` automatically.
 - Never publish without testing as consumer — `npm run check` passing does NOT mean the package works for end users. Always run `npm run verify-package`.
+- The Dockerfile is multi-stage and **self-building** (compiles `src/` in a build stage) — never make it depend on a pre-built `dist/`, and keep `src/` + `tsconfig.json` out of `.dockerignore`. The runtime stage uses `npm ci --omit=dev --ignore-scripts` (the `prepare` script would run tsc without dev deps) followed by `npm rebuild ffmpeg-static` (its postinstall downloads the ffmpeg binary; skipping it ships an image with no frame extraction). Smithery is unaffected (`smithery.yaml` launches via npx).
 
 ## Dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,25 @@
+# Build stage: compile TypeScript from source. CI builders (Glama) clone the
+# repo fresh — dist/ is gitignored, so the image must build it itself.
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json tsconfig.json ./
+RUN npm ci --ignore-scripts
+
+COPY src/ ./src/
+RUN npm run build
+
+# Runtime stage: production deps only. --ignore-scripts skips the local
+# `prepare` script (which would run tsc without dev deps); ffmpeg-static's
+# postinstall (downloads the ffmpeg binary) is then run explicitly via rebuild.
 FROM node:20-slim
 
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev --ignore-scripts
+RUN npm ci --omit=dev --ignore-scripts && npm rebuild ffmpeg-static
 
-COPY dist/ ./dist/
+COPY --from=build /app/dist/ ./dist/
 
 ENTRYPOINT ["node", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-video-analyzer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "MCP server for video analysis — extracts transcripts, key frames, OCR text, and metadata from video URLs and local files. Supports Loom, YouTube and other yt-dlp platforms, direct video URLs, and local video files.",
   "author": "guimatheus92",
   "license": "MIT",

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import { registerGetTranscript } from './tools/get-transcript.js';
 export function createServer(): FastMCP {
   const server = new FastMCP({
     name: 'mcp-video-analyzer',
-    version: '0.6.0',
+    version: '0.6.1',
     instructions: `Video analysis MCP server. Extracts transcripts, key frames, metadata, comments, OCR text, and annotated timelines from video URLs and local video files.
 
 AUTOMATIC BEHAVIOR — Do NOT wait for the user to ask:


### PR DESCRIPTION
## Summary

Fixes the Glama CI build failure ("Build failed for mcp-video-analyzer" email on every release). Glama builds the Dockerfile from a fresh git checkout — and `dist/` is gitignored, so `COPY dist/ ./dist/` failed deterministically with `"/dist": not found` (reproduced locally by building from a `git archive` clean-clone simulation). The image only ever built on a machine that had run `npm run build` first.

## Changes

- **Dockerfile**: now multi-stage and self-building — a build stage runs `npm ci --ignore-scripts` + `tsc` from `src/`, and the runtime stage installs production deps and copies the compiled `dist/` from the build stage.
- **Second latent bug fixed**: the old `npm ci --omit=dev --ignore-scripts` skipped `ffmpeg-static`'s postinstall (which downloads the ffmpeg binary), so even a successfully-built image had no frame extraction. The runtime stage now runs `npm rebuild ffmpeg-static` after the install (`--ignore-scripts` must stay on the `ci` itself because the local `prepare` script would run tsc without dev deps).
- **.dockerignore**: `src/` and `tsconfig.json` now enter the build context; `dist/` is excluded so a stale local build can never leak into the image; `tsconfig.eslint.json` stays out.
- **CLAUDE.md**: the release process gained a mandatory step — validate the Docker image from a clean clone before publishing — plus a Notes entry documenting the self-building contract, so this cannot silently regress.
- **Version**: 0.6.1 (infra patch; the npm package content is unchanged — Smithery is also unaffected since `smithery.yaml` launches via npx).

## Validation (all from a clean-clone simulation, no local dist/)

1. Reproduced the failure first on the old Dockerfile: `ERROR: "/dist": not found`.
2. `docker build` on the fixed Dockerfile: passes.
3. `require('ffmpeg-static')` inside the image resolves to an existing binary (`/app/node_modules/ffmpeg-static/ffmpeg`).
4. The container answers an MCP `initialize` request over stdio: `mcp-video-analyzer v0.6.1`.
5. `npm run check` (379 tests) and `npm run verify-package` green at 0.6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
