### PR TITLE
CI: validate Docker image on every PR (build + ffmpeg + MCP initialize)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,22 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm run test:e2e
+
+  # Replicates what Glama CI does on every release: build the Dockerfile from
+  # a fresh clone (dist/ is gitignored — the image must compile itself) and
+  # prove the container actually works. See CLAUDE.md → Publishing.
+  docker-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image from clean clone
+        run: docker build -t mcp-video-analyzer:ci .
+      - name: Verify ffmpeg binary inside the image
+        run: >
+          docker run --rm --entrypoint node mcp-video-analyzer:ci
+          -e "const p=require('ffmpeg-static');if(!require('fs').existsSync(p)){console.error('ffmpeg binary missing:',p);process.exit(1)}console.log('ffmpeg ok:',p)"
+      - name: Verify MCP server answers initialize
+        run: |
+          RESPONSE=$(echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' | timeout 30 docker run -i --rm mcp-video-analyzer:ci | head -n 1)
+          echo "$RESPONSE" | grep -q '"result"' || { echo "No initialize result. Got: $RESPONSE"; exit 1; }
+          echo "MCP initialize OK"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 2. **Run checks**: `npm run check` (format, lint, typecheck, knip, tests).
 3. **Run smoke test**: `npm run test:smoke` (verifies MCP server starts and responds).
 4. **Run package verification**: `npm run verify-package` (packs tarball, installs in temp dir, verifies startup).
-5. **Validate the Docker image from a clean clone** (Glama CI builds it from git on every release — `dist/` is gitignored, so the image must compile itself): `git archive HEAD -o sim.tar` → extract to an empty dir → `docker build` there → send an MCP `initialize` to `docker run -i` and expect a response. A build that only works with a locally pre-built `dist/` WILL fail on Glama and email the maintainer.
+5. **Docker image validation** — the `docker-image` CI job runs it on every PR (build from clean clone + ffmpeg present + MCP `initialize` answered), replicating what Glama CI does on each release; `dist/` is gitignored, so the image must compile itself. Confirm the job is green before releasing. Manual fallback: `git archive HEAD -o sim.tar` → extract to an empty dir → `docker build` there → pipe an MCP `initialize` into `docker run -i`. A build that only works with a locally pre-built `dist/` WILL fail on Glama and email the maintainer.
 6. **Commit & push**: commit version bump to main.
 7. **Publish to npm**: `npm publish`.
 8. **Create GitHub release**: `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`.


### PR DESCRIPTION
## Summary

Adds a third CI job, **docker-image**, that replicates on every PR exactly what Glama CI does on each release — so a Dockerfile regression is caught before merge instead of via a Glama build-failure email (the incident fixed in #16):

1. **Build from clean clone** — GitHub Actions checkout has no gitignored dist/, same as Glama's fresh clone; the image must compile itself.
2. **ffmpeg binary present** — asserts require('ffmpeg-static') resolves to an existing file inside the image (the latent bug #16 also fixed).
3. **MCP initialize answered** — pipes a JSON-RPC initialize into docker run -i and requires a result line.

CLAUDE.md release step 5 now points at this job (manual clean-clone recipe kept as fallback).

## Validation

The docker-image job runs on this very PR — its green check IS the end-to-end validation of the workflow.

No version bump: workflow file is not part of the npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)