### PR TITLE
feat: /video agent skill + one-shot CLI + Claude Code plugin packaging (v0.7.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "mcp-video-analyzer",
+  "metadata": {
+    "description": "Video analysis for AI agents: transcripts, key frames, OCR, and annotated timelines from Loom, YouTube, Instagram, TikTok, direct URLs, and local files."
+  },
+  "owner": {
+    "name": "Guilherme Matheus"
+  },
+  "plugins": [
+    {
+      "name": "video",
+      "description": "Watch a video with /video — transcript, key frames, OCR, and timeline from a URL or local file, answered with timestamps.",
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://github.com/guimatheus92/mcp-video-analyzer"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "video",
+  "description": "Give your agent video input. /video analyzes a URL or local file — transcript, key frames, OCR, timeline — via the mcp-video-analyzer MCP server (auto-registered) or its CLI.",
+  "version": "0.7.0",
+  "author": {
+    "name": "Guilherme Matheus"
+  },
+  "homepage": "https://github.com/guimatheus92/mcp-video-analyzer"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "video-analyzer": {
+      "command": "npx",
+      "args": ["-y", "mcp-video-analyzer@latest"]
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Without the skill, the one-shot CLI works from any shell (Node 18+ only; ffmpeg 
 npx -y mcp-video-analyzer@latest analyze "<video-url-or-path>"
 ```
 
-stdout is a single JSON document (`metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, `frames[].filePath` → JPEG key frames on disk). Progress goes to stderr. Read the frame images for visual questions; answer with timestamps. `analyze --help` lists all flags.
+stdout is a single JSON document (`metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, and `frames` as `{ time, filePath, mimeType }` → JPEG key frames on disk). Progress goes to stderr. Read the frame images for visual questions; answer with timestamps. `analyze --help` lists all flags.
 
 ## MCP alternative
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+Instructions for AI agents (Codex, Cursor, Copilot, Gemini CLI, …) using this project as a tool. For contributing to the codebase itself, see [CLAUDE.md](CLAUDE.md) and [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Analyzing a video
+
+Preferred: install the `video` skill and follow its contract — [skills/video/SKILL.md](skills/video/SKILL.md):
+
+```bash
+npx skills add guimatheus92/mcp-video-analyzer
+```
+
+Without the skill, the one-shot CLI works from any shell (Node 18+ only; ffmpeg is bundled):
+
+```bash
+npx -y mcp-video-analyzer@latest analyze "<video-url-or-path>"
+```
+
+stdout is a single JSON document (`metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, `frames[].filePath` → JPEG key frames on disk). Progress goes to stderr. Read the frame images for visual questions; answer with timestamps. `analyze --help` lists all flags.
+
+## MCP alternative
+
+If your agent supports MCP, register the stdio server instead — richer tool set (`analyze_video`, `analyze_moment`, `get_transcript`, `get_metadata`, `get_frames`, `get_frame_at`, `get_frame_burst`, `analyze_videos`) with frames returned inline:
+
+```json
+{ "command": "npx", "args": ["-y", "mcp-video-analyzer@latest"] }
+```
+
+## Notes
+
+- Platform URLs (YouTube, Instagram, TikTok, …) need `yt-dlp` on PATH; Loom, direct `.mp4/.webm/.mov` URLs, and local files don't.
+- The `warnings` array carries actionable hints (yt-dlp install, cookies via `YTDLP_COOKIES_FROM_BROWSER`, Whisper backends) — relay them, don't treat them as errors.
+- An empty transcript plus a "silent audio" warning means the video has no speech; that's content, not a failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-MCP server for video analysis — extracts transcripts, key frames, metadata, OCR text, and annotated timelines from video URLs (Loom, YouTube and other yt-dlp platforms, direct links) and local video files.
+MCP server for video analysis — extracts transcripts, key frames, metadata, OCR text, and annotated timelines from video URLs (Loom, YouTube and other yt-dlp platforms, direct links) and local video files. The same engine is also exposed as a one-shot CLI (`mcp-video-analyzer analyze <url>`) and as the portable `/video` agent skill (`skills/video/SKILL.md` + Claude Code plugin).
 
 ## Commands
 
@@ -15,6 +15,7 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 - `npm run lint:fix` — auto-fix lint issues
 - `npm run format` — auto-format with Prettier
 - `npm run inspect` — open FastMCP inspector for manual testing
+- `node dist/index.js analyze <url> [flags]` — run the one-shot CLI against the local build (after `npm run build`)
 - `npx tsx examples/generate.ts` — regenerate example outputs (run after changing tool output format, processors, or adapters)
 
 ## Architecture
@@ -23,6 +24,8 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 - **Processors** (`src/processors/`) — shared processing: frame extraction (ffmpeg + browser fallback), image optimization + OCR preprocessing (sharp), frame dedup (dHash, visual + OCR-text-aware), OCR (tesseract.js), audio transcription (whisper), annotated timeline.
 - **Tools** (`src/tools/`) — MCP tool definitions registered on the FastMCP server. `analyze-core.ts` holds the shared cache + pipeline (`getAnalysis`) + content builder reused by both `analyze_video` and the batch `analyze_videos`.
 - **Utils** (`src/utils/`) — URL detection, VTT parsing, temp files, in-memory + on-disk cache (`cache.ts`, `analysis-sidecar.ts`), bounded concurrency (`concurrency.ts`), env-flag parsing (`env.ts`).
+- **CLI** (`src/cli.ts`) — one-shot `analyze` subcommand (`mcp-video-analyzer analyze <url>`) reusing the same `getAnalysis` pipeline: single JSON document on stdout, progress/errors on stderr, frame JPEGs copied to `--out` (default `<tmp>/mcp-video-analyzer/<url-hash>/`) *before* `handle.cleanup()`. `src/index.ts` dispatches on `argv[2]` — no args = MCP stdio server (Docker/smithery/MCP configs rely on this). Adapter registration is shared via `registerAllAdapters()` in `server.ts`. Version literal lives in `src/version.ts`.
+- **Skill + plugin** (`skills/video/SKILL.md`, `.claude-plugin/`, root `.mcp.json`) — the `/video` agent skill (Route A: MCP tools; Route B: the CLI via npx) and Claude Code plugin/marketplace manifests; the root `.mcp.json` is the plugin's bundled server config (auto-registered on `/plugin install`). Installed from GitHub, never shipped in the npm tarball (`files: ["dist"]`).
 
 ## Conventions
 
@@ -46,6 +49,9 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 - The whisper CLI is run directly (no `--help` probe — it double-imports torch and crashes on Windows on non-ASCII help text); `ENOENT` distinguishes "not installed" (try next candidate) from "installed but crashed" (warn). Spawned with `PYTHONUTF8=1`/`PYTHONIOENCODING=utf-8` so multilingual transcripts don't crash the Python stdout codec. When NO backend is configured at all, `transcribeAudio` emits an actionable "No speech-to-text backend available" warning instead of a bare `[]`.
 - yt-dlp errors that look auth-related (login/cookies/private/age-restricted/empty-media/rate-limit) get a cookie hint appended by `extractYtDlpError` naming this server's env vars (`YTDLP_COOKIES` / `YTDLP_COOKIES_FROM_BROWSER`), not yt-dlp's raw CLI flags.
 - Persistent sidecars (`MCP_WRITE_SIDECARS=1`) write `<stem>.vtt` (Whisper transcripts only, never clobbering an existing one) + `<stem>.analysis.json` + `<stem>.frames/` next to local videos for resumable bulk processing; reads validate `mtime:size` + params.
+- CLI mode: stdout is reserved for the single JSON result document — progress, warnings-in-flight, and errors go to stderr. CLI flags validate through the shared `AnalyzeOptionsSchema` (no hand-rolled validation). Partial failures ride in `warnings[]` with exit 0; only hard failures exit 1.
+- `skills/video/SKILL.md` is a public contract: any change to MCP tool names, CLI flags, or the CLI JSON shape must update `skills/video/SKILL.md` + `README.md` + `AGENTS.md` in the same PR.
+- Tesseract `.traineddata` downloads are cached in `<tmp>/mcp-video-analyzer/tessdata` via `cachePath` (frame-ocr.ts) — never let them land in the process cwd (pollutes the agent's project dir under npx).
 
 ## Environment Variables
 
@@ -59,7 +65,7 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 
 ### Release Process
 
-1. **Bump version** in both `package.json` AND `src/server.ts` (must match).
+1. **Bump version** in `package.json`, `src/version.ts` AND `.claude-plugin/plugin.json` (must match).
 2. **Run checks**: `npm run check` (format, lint, typecheck, knip, tests).
 3. **Run smoke test**: `npm run test:smoke` (verifies MCP server starts and responds).
 4. **Run package verification**: `npm run verify-package` (packs tarball, installs in temp dir, verifies startup).
@@ -67,7 +73,7 @@ MCP server for video analysis — extracts transcripts, key frames, metadata, OC
 6. **Commit & push**: commit version bump to main.
 7. **Publish to npm**: `npm publish`.
 8. **Create GitHub release**: `gh release create vX.Y.Z --title "vX.Y.Z" --generate-notes`.
-9. **Update .mcp.json**: pin new version in local MCP config.
+9. **Update local MCP config**: pin the new version in your machine's own MCP client config (NOT the repo-root `.mcp.json`, which is the plugin's bundled server config and stays on `@latest`).
 10. **Verify on npm**: `npm view mcp-video-analyzer version`.
 
 ### Notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,13 @@ src/
 ├── adapters/     # Platform-specific logic (Loom, direct URL)
 ├── processors/   # Frame extraction, optimization, dedup, OCR, timeline
 ├── utils/        # URL detection, VTT parsing, temp files
+├── cli.ts        # One-shot `analyze` subcommand (same pipeline, JSON on stdout)
 └── types.ts      # Shared TypeScript interfaces
+skills/video/     # The portable `video` agent skill (SKILL.md contract)
+.claude-plugin/   # Claude Code plugin + marketplace manifests (with root .mcp.json)
 ```
+
+`skills/` and `.claude-plugin/` are installed from GitHub (Claude Code plugin marketplace / `npx skills add`), not from the npm tarball. The SKILL.md is a public contract: if you change MCP tool names, CLI flags, or the CLI JSON shape, update `skills/video/SKILL.md`, `README.md`, and `AGENTS.md` in the same PR.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -111,13 +111,13 @@ The same engine is exposed as a one-shot command — this is what the `video` sk
 npx -y mcp-video-analyzer@latest analyze "https://youtu.be/jNQXAC9IVRw"
 ```
 
-stdout is a single JSON document — `metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, `frameCount`, and `frames` as `{ time, filePath }` entries pointing at JPEG key frames copied to `--out` (default: `<tmp>/mcp-video-analyzer/<url-hash>/`). Progress streams on stderr, so `stdout` can be piped straight into a JSON parser. Partial failures land in `warnings` with exit code 0; only hard failures exit 1.
+stdout is a single JSON document — `metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, `frameCount`, and `frames` as `{ time, filePath, mimeType }` entries pointing at JPEG key frames copied to `--out` (default: `<tmp>/mcp-video-analyzer/<url-hash>/`). Progress streams on stderr, so `stdout` can be piped straight into a JSON parser. Partial failures land in `warnings` with exit code 0; only hard failures exit 1.
 
 | Flag | Description |
 |------|-------------|
 | `--detail <level>` | `brief` (metadata + transcript, no frames), `standard` (default), `detailed` |
 | `--max-frames <n>` | Max key frames, 1–60 (default adapts to duration) |
-| `--fields <list>` | Comma-separated subset: `metadata,transcript,frames,comments,chapters,ocrResults,timeline,aiSummary` |
+| `--fields <list>` | Output filter — comma-separated subset: `metadata,transcript,frames,comments,chapters,ocrResults,timeline,aiSummary`. Filters the emitted JSON only; use `--detail brief` to actually skip download/frame extraction |
 | `--force-refresh` | Bypass the cache and re-analyze |
 | `--ocr-language <codes>` | Tesseract languages (default `eng+por`) |
 | `--model <name>` / `--language <code>` | Whisper overrides for the transcription fallback |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,31 @@ No existing video MCP combines **transcripts + visual frames + metadata** in one
 
 > Without yt-dlp or Chrome, direct URLs and local files still get frames — the bundled `ffmpeg-static` does the extraction, and Loom falls back to its own CDN download. Platform URLs (YouTube etc.) degrade to a clear "install yt-dlp" warning. Transcripts, metadata, and comments never require either.
 
-### Claude Code (CLI)
+There are three ways in: the **`/video` plugin** (Claude Code — slash command + MCP server auto-configured), a plain **MCP server** config (any MCP client), or the **portable skill + CLI** (Codex, Cursor, Copilot, and any agent with a shell — no MCP required).
+
+### Claude Code — `/video` plugin (recommended)
+
+```
+/plugin marketplace add guimatheus92/mcp-video-analyzer
+/plugin install video@mcp-video-analyzer
+```
+
+This adds the `/video` slash command **and** auto-registers the MCP server — no `claude mcp add` needed:
+
+```
+/video https://youtu.be/jNQXAC9IVRw what happens at 0:10?
+/video ~/Movies/screen-recording.mp4 when does the UI break?
+```
+
+### Other agents — Codex, Cursor, Copilot, Gemini CLI, …
+
+```bash
+npx skills add guimatheus92/mcp-video-analyzer
+```
+
+Installs the `video` skill ([Agent Skills](https://github.com/vercel-labs/skills) format) into every agent detected on your machine. Agents without the MCP server configured fall back to the bundled [CLI](#cli-one-shot-no-mcp-client) automatically — zero configuration.
+
+### Claude Code (MCP only)
 
 ```bash
 claude mcp add video-analyzer -- npx mcp-video-analyzer@latest
@@ -78,6 +102,28 @@ Add to your Claude Desktop config file:
 ```
 
 Then restart Claude Desktop.
+
+### CLI (one-shot, no MCP client)
+
+The same engine is exposed as a one-shot command — this is what the `video` skill uses on agents without MCP, and it works standalone in any terminal:
+
+```bash
+npx -y mcp-video-analyzer@latest analyze "https://youtu.be/jNQXAC9IVRw"
+```
+
+stdout is a single JSON document — `metadata`, `transcript`, `ocrResults`, `timeline`, `warnings`, `frameCount`, and `frames` as `{ time, filePath }` entries pointing at JPEG key frames copied to `--out` (default: `<tmp>/mcp-video-analyzer/<url-hash>/`). Progress streams on stderr, so `stdout` can be piped straight into a JSON parser. Partial failures land in `warnings` with exit code 0; only hard failures exit 1.
+
+| Flag | Description |
+|------|-------------|
+| `--detail <level>` | `brief` (metadata + transcript, no frames), `standard` (default), `detailed` |
+| `--max-frames <n>` | Max key frames, 1–60 (default adapts to duration) |
+| `--fields <list>` | Comma-separated subset: `metadata,transcript,frames,comments,chapters,ocrResults,timeline,aiSummary` |
+| `--force-refresh` | Bypass the cache and re-analyze |
+| `--ocr-language <codes>` | Tesseract languages (default `eng+por`) |
+| `--model <name>` / `--language <code>` | Whisper overrides for the transcription fallback |
+| `--out <dir>` | Where frame images are copied |
+
+Run with no arguments (`npx mcp-video-analyzer@latest`) to start the MCP stdio server — the CLI is purely additive.
 
 ### Verify it works
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-video-analyzer",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "description": "MCP server for video analysis — extracts transcripts, key frames, OCR text, and metadata from video URLs and local files. Supports Loom, YouTube and other yt-dlp platforms, direct video URLs, and local video files.",
   "author": "guimatheus92",
   "license": "MIT",
@@ -59,6 +59,11 @@
     "ocr",
     "screen-recording",
     "claude",
+    "claude-code",
+    "claude-skill",
+    "claude-plugin",
+    "agent-skills",
+    "cli",
     "ai"
   ],
   "engines": {

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -2,7 +2,7 @@
 name: video
 description: Analyze a video (Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch, Dailymotion, Facebook, direct URL, or local file) — transcript, key frames, OCR text, metadata, annotated timeline — and answer questions about it with timestamps.
 argument-hint: "<video-url-or-path> [question]"
-allowed-tools: Bash, Read
+allowed-tools: Bash, Read, mcp__video-analyzer
 homepage: https://github.com/guimatheus92/mcp-video-analyzer
 license: MIT
 ---
@@ -27,13 +27,13 @@ Run the one-shot CLI via Bash (first run downloads the npm package — slow is n
 npx -y mcp-video-analyzer@latest analyze "<video-url-or-path>"
 ```
 
-stdout is a single JSON document: `metadata`, `transcript` (timestamped entries), `ocrResults` (on-screen text), `timeline`, `warnings`, and `frames` — an array of `{ time, filePath }` pointing to JPEG key frames on disk. Then:
+stdout is a single JSON document: `metadata`, `transcript` (timestamped entries), `ocrResults` (on-screen text), `timeline`, `warnings`, and `frames` — an array of `{ time, filePath, mimeType }` pointing to JPEG key frames on disk. Then:
 
 1. Parse the JSON from stdout.
 2. Read the `frames[].filePath` images (in parallel) when the question needs visuals.
 3. Answer from transcript + OCR + frames, citing timestamps.
 
-Useful flags: `--detail brief|standard|detailed` (brief = metadata + transcript only, no frames), `--fields metadata,transcript` (skip everything else), `--max-frames <1-60>`, `--language <code>` (force transcription language), `--out <dir>` (where frames are copied), `--force-refresh`. Run `npx -y mcp-video-analyzer@latest analyze --help` for the full list.
+Useful flags: `--detail brief|standard|detailed` (brief = metadata + transcript only, no frame extraction — the fast/cheap path), `--fields metadata,transcript` (filters the emitted JSON only; frames are still computed at standard detail), `--max-frames <1-60>`, `--language <code>` (force transcription language), `--out <dir>` (where frames are copied), `--force-refresh`. Run `npx -y mcp-video-analyzer@latest analyze --help` for the full list.
 
 ## Prerequisites & degradation
 

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: video
+description: Analyze a video (Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch, Dailymotion, Facebook, direct URL, or local file) — transcript, key frames, OCR text, metadata, annotated timeline — and answer questions about it with timestamps.
+argument-hint: "<video-url-or-path> [question]"
+allowed-tools: Bash, Read
+homepage: https://github.com/guimatheus92/mcp-video-analyzer
+license: MIT
+---
+
+Analyze the given video and answer the user's question (or summarize it if no question was asked). Always cite timestamps (`M:SS`) in your answer.
+
+## Route A — video-analyzer MCP tools available (preferred)
+
+If the `video-analyzer` MCP server is connected in this session, call its tools directly — do not use the CLI:
+
+- General question or no question → `analyze_video` (detail `"standard"`)
+- "What happens at X:XX" / a specific moment → `analyze_moment` (time range) or `get_frame_at`
+- Question answerable from speech alone → `get_transcript` (fast, no download)
+- Title / duration / views / comments only → `get_metadata` (no download)
+- Motion or fast UI changes → `get_frame_burst`
+
+## Route B — no MCP server (any agent with a shell)
+
+Run the one-shot CLI via Bash (first run downloads the npm package — slow is not broken; progress streams on stderr):
+
+```bash
+npx -y mcp-video-analyzer@latest analyze "<video-url-or-path>"
+```
+
+stdout is a single JSON document: `metadata`, `transcript` (timestamped entries), `ocrResults` (on-screen text), `timeline`, `warnings`, and `frames` — an array of `{ time, filePath }` pointing to JPEG key frames on disk. Then:
+
+1. Parse the JSON from stdout.
+2. Read the `frames[].filePath` images (in parallel) when the question needs visuals.
+3. Answer from transcript + OCR + frames, citing timestamps.
+
+Useful flags: `--detail brief|standard|detailed` (brief = metadata + transcript only, no frames), `--fields metadata,transcript` (skip everything else), `--max-frames <1-60>`, `--language <code>` (force transcription language), `--out <dir>` (where frames are copied), `--force-refresh`. Run `npx -y mcp-video-analyzer@latest analyze --help` for the full list.
+
+## Prerequisites & degradation
+
+- Node.js 18+ (required). `ffmpeg` is bundled — no install needed.
+- Platform URLs (YouTube, Instagram, TikTok, …) require `yt-dlp` on PATH; Loom, direct `.mp4/.webm/.mov` URLs, and local files work without it.
+- The tool never fails on partial results: the `warnings` array carries actionable hints (yt-dlp install, `YTDLP_COOKIES_FROM_BROWSER` for Instagram/age-restricted, missing Whisper backend). Relay relevant warnings to the user instead of treating them as errors.
+- An empty transcript alongside a "silent audio" warning means the video genuinely has no speech (common for muted Reels/Stories) — that is content, not a failure.

--- a/src/adapters/register.ts
+++ b/src/adapters/register.ts
@@ -1,0 +1,23 @@
+import { registerAdapter } from './adapter.interface.js';
+import { DirectAdapter } from './direct.adapter.js';
+import { LocalFileAdapter } from './local-file.adapter.js';
+import { LoomAdapter } from './loom.adapter.js';
+import { TwelveLabsAdapter } from './twelvelabs.adapter.js';
+import { YtDlpAdapter } from './ytdlp.adapter.js';
+
+/**
+ * Register the platform adapters (order matters: more specific first).
+ * Shared wiring for both entry points — the MCP server (`server.ts`) and the
+ * one-shot CLI (`cli.ts`) — so neither depends on the other.
+ *
+ * TwelveLabsAdapter precedes DirectAdapter: when TWELVELABS_API_KEY is set it
+ * takes over direct video URLs (Pegasus transcript + AI summary); otherwise
+ * it declines and DirectAdapter handles them as before.
+ */
+export function registerAllAdapters(): void {
+  registerAdapter(new LoomAdapter());
+  registerAdapter(new LocalFileAdapter());
+  registerAdapter(new YtDlpAdapter());
+  registerAdapter(new TwelveLabsAdapter());
+  registerAdapter(new DirectAdapter());
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,127 @@
+import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createTestImage } from '../test/helpers/index.js';
+import { copyFrames, defaultOutDir, parseCliArgs } from './cli.js';
+import type { IFrameResult } from './types.js';
+
+describe('parseCliArgs', () => {
+  it('maps flags to analyze options', () => {
+    const parsed = parseCliArgs([
+      'https://example.com/video.mp4',
+      '--detail',
+      'brief',
+      '--max-frames',
+      '10',
+      '--fields',
+      'metadata, transcript',
+      '--force-refresh',
+      '--ocr-language',
+      'eng',
+      '--model',
+      'small',
+      '--language',
+      'pt',
+      '--out',
+      '/tmp/frames',
+    ]);
+
+    expect(parsed.url).toBe('https://example.com/video.mp4');
+    expect(parsed.outDir).toBe('/tmp/frames');
+    expect(parsed.help).toBe(false);
+    expect(parsed.options).toEqual({
+      detail: 'brief',
+      maxFrames: 10,
+      fields: ['metadata', 'transcript'],
+      forceRefresh: true,
+      ocrLanguage: 'eng',
+      model: 'small',
+      language: 'pt',
+    });
+  });
+
+  it('returns undefined options when no flags are given', () => {
+    const parsed = parseCliArgs(['https://example.com/video.mp4']);
+    expect(parsed.options).toBeUndefined();
+    expect(parsed.outDir).toBeUndefined();
+  });
+
+  it('sets help for -h without requiring a url', () => {
+    expect(parseCliArgs(['-h']).help).toBe(true);
+    expect(parseCliArgs(['--help']).help).toBe(true);
+  });
+
+  it('rejects a non-numeric --max-frames', () => {
+    expect(() => parseCliArgs(['url', '--max-frames', 'abc'])).toThrow();
+  });
+
+  it('rejects an out-of-range --max-frames', () => {
+    expect(() => parseCliArgs(['url', '--max-frames', '999'])).toThrow();
+  });
+
+  it('rejects an invalid --detail level', () => {
+    expect(() => parseCliArgs(['url', '--detail', 'wrong'])).toThrow();
+  });
+
+  it('rejects an unknown --fields entry', () => {
+    expect(() => parseCliArgs(['url', '--fields', 'bogus'])).toThrow();
+  });
+
+  it('rejects unknown flags', () => {
+    expect(() => parseCliArgs(['url', '--nope'])).toThrow();
+  });
+});
+
+describe('defaultOutDir', () => {
+  it('is stable for the same source and distinct across sources', () => {
+    const a = defaultOutDir('https://example.com/a.mp4');
+    expect(defaultOutDir('https://example.com/a.mp4')).toBe(a);
+    expect(defaultOutDir('https://example.com/b.mp4')).not.toBe(a);
+    expect(a).toContain('mcp-video-analyzer');
+  });
+});
+
+describe('copyFrames', () => {
+  const tempDirs: string[] = [];
+
+  async function makeTempDir(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), 'cli-test-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it('copies frames to the out dir, rewriting paths and counting missing sources', async () => {
+    const srcDir = await makeTempDir();
+    const outDir = join(await makeTempDir(), 'frames');
+
+    const frames: IFrameResult[] = [
+      {
+        time: '0:00',
+        filePath: await createTestImage(srcDir, 'frame_0001.jpg'),
+        mimeType: 'image/jpeg',
+      },
+      {
+        time: '0:05',
+        filePath: await createTestImage(srcDir, 'frame_0002.jpg'),
+        mimeType: 'image/jpeg',
+      },
+      { time: '0:10', filePath: join(srcDir, 'frame_gone.jpg'), mimeType: 'image/jpeg' },
+    ];
+
+    const { frames: copied, missing } = await copyFrames(frames, outDir);
+
+    expect(missing).toBe(1);
+    expect(copied).toHaveLength(2);
+    expect(copied.map((f) => f.time)).toEqual(['0:00', '0:05']);
+    for (const frame of copied) {
+      expect(frame.filePath.startsWith(outDir)).toBe(true);
+      await expect(stat(frame.filePath)).resolves.toBeDefined();
+    }
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,10 +1,17 @@
-import { mkdtemp, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createTestImage } from '../test/helpers/index.js';
-import { copyFrames, defaultOutDir, parseCliArgs } from './cli.js';
-import type { IFrameResult } from './types.js';
+import { copyFrames, defaultOutDir, parseCliArgs, runCli } from './cli.js';
+import { getAnalysis } from './tools/analyze-core.js';
+import type * as analyzeCore from './tools/analyze-core.js';
+import type { IAnalysisResult, IFrameResult } from './types.js';
+
+vi.mock('./tools/analyze-core.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof analyzeCore>();
+  return { ...actual, getAnalysis: vi.fn(actual.getAnalysis) };
+});
 
 describe('parseCliArgs', () => {
   it('maps flags to analyze options', () => {
@@ -82,20 +89,21 @@ describe('defaultOutDir', () => {
   });
 });
 
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'cli-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+  vi.restoreAllMocks();
+});
+
 describe('copyFrames', () => {
-  const tempDirs: string[] = [];
-
-  async function makeTempDir(): Promise<string> {
-    const dir = await mkdtemp(join(tmpdir(), 'cli-test-'));
-    tempDirs.push(dir);
-    return dir;
-  }
-
-  afterEach(async () => {
-    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
-    tempDirs.length = 0;
-  });
-
   it('copies frames to the out dir, rewriting paths and counting missing sources', async () => {
     const srcDir = await makeTempDir();
     const outDir = join(await makeTempDir(), 'frames');
@@ -114,14 +122,134 @@ describe('copyFrames', () => {
       { time: '0:10', filePath: join(srcDir, 'frame_gone.jpg'), mimeType: 'image/jpeg' },
     ];
 
-    const { frames: copied, missing } = await copyFrames(frames, outDir);
+    const { frames: copied, missing, errors } = await copyFrames(frames, outDir);
 
     expect(missing).toBe(1);
+    expect(errors).toEqual([]);
     expect(copied).toHaveLength(2);
     expect(copied.map((f) => f.time)).toEqual(['0:00', '0:05']);
     for (const frame of copied) {
       expect(frame.filePath.startsWith(outDir)).toBe(true);
       await expect(stat(frame.filePath)).resolves.toBeDefined();
     }
+  });
+
+  it('reports non-ENOENT copy failures as errors, not as missing frames', async () => {
+    const srcDir = await makeTempDir();
+    const outDir = await makeTempDir();
+
+    const framePath = await createTestImage(srcDir, 'frame_0001.jpg');
+    // A directory occupying the destination path forces a non-ENOENT failure
+    // (EPERM/EISDIR depending on platform).
+    await mkdir(join(outDir, 'frame_0001.jpg'));
+
+    const { frames, missing, errors } = await copyFrames(
+      [{ time: '0:00', filePath: framePath, mimeType: 'image/jpeg' }],
+      outDir,
+    );
+
+    expect(frames).toEqual([]);
+    expect(missing).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Frame copy to');
+    expect(errors[0]).not.toContain('force-refresh');
+  });
+});
+
+describe('runCli', () => {
+  function captureStreams(): { stdout: () => string; stderr: () => string } {
+    let out = '';
+    let err = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      out += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      err += String(chunk);
+      return true;
+    });
+    return { stdout: () => out, stderr: () => err };
+  }
+
+  function fakeResult(frames: IFrameResult[]): IAnalysisResult {
+    return {
+      metadata: {
+        platform: 'local',
+        title: 'fake',
+        duration: 1,
+        durationFormatted: '0:01',
+        url: 'C:/videos/fake.mp4',
+      },
+      transcript: [],
+      frames,
+      comments: [],
+      chapters: [],
+      ocrResults: [],
+      timeline: [],
+      warnings: ['base warning'],
+    };
+  }
+
+  it('exits 1 with stderr only when the analysis hard-fails', async () => {
+    const streams = captureStreams();
+    vi.mocked(getAnalysis).mockRejectedValueOnce(new Error('pipeline exploded'));
+
+    const code = await runCli([join(tmpdir(), 'whatever.mp4')]);
+
+    expect(code).toBe(1);
+    expect(streams.stdout()).toBe('');
+    expect(streams.stderr()).toContain('pipeline exploded');
+  });
+
+  it('degrades a failed frame copy into warnings, still runs cleanup and exits 0', async () => {
+    const streams = captureStreams();
+    const cleanup = vi.fn(async () => undefined);
+    const srcDir = await makeTempDir();
+    const framePath = await createTestImage(srcDir, 'frame_0001.jpg');
+    vi.mocked(getAnalysis).mockResolvedValueOnce({
+      result: fakeResult([{ time: '0:00', filePath: framePath, mimeType: 'image/jpeg' }]),
+      cleanup,
+    });
+    // An --out whose parent is a FILE makes copyFrames' mkdir reject.
+    const bogusOut = join(framePath, 'sub');
+
+    const code = await runCli([join(tmpdir(), 'whatever.mp4'), '--out', bogusOut]);
+
+    expect(code).toBe(0);
+    expect(cleanup).toHaveBeenCalled();
+    const doc = JSON.parse(streams.stdout());
+    expect(doc.frames).toEqual([]);
+    expect(doc.warnings).toContain('base warning');
+    expect(doc.warnings.some((w: string) => w.includes('Frame images could not be copied'))).toBe(
+      true,
+    );
+  });
+
+  it('appends the missing-frames warning when source frames are already gone', async () => {
+    const streams = captureStreams();
+    const cleanup = vi.fn(async () => undefined);
+    const srcDir = await makeTempDir();
+    vi.mocked(getAnalysis).mockResolvedValueOnce({
+      result: fakeResult([
+        { time: '0:00', filePath: join(srcDir, 'frame_gone.jpg'), mimeType: 'image/jpeg' },
+      ]),
+      cleanup,
+    });
+
+    const code = await runCli([
+      join(tmpdir(), 'whatever.mp4'),
+      '--out',
+      join(await makeTempDir(), 'frames'),
+    ]);
+
+    expect(code).toBe(0);
+    expect(cleanup).toHaveBeenCalled();
+    const doc = JSON.parse(streams.stdout());
+    expect(doc.frames).toEqual([]);
+    expect(doc.frameCount).toBe(1);
+    expect(
+      doc.warnings.some((w: string) => w.includes('1 of 1 frame image(s) were unavailable')),
+    ).toBe(true);
+    expect(doc.warnings.some((w: string) => w.includes('--force-refresh'))).toBe(true);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,201 @@
+import { createHash } from 'node:crypto';
+import { copyFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { parseArgs } from 'node:util';
+import { ZodError } from 'zod';
+import { registerAllAdapters } from './server.js';
+import { AnalyzeOptionsSchema, getAnalysis, resolveAnalyzeParams } from './tools/analyze-core.js';
+import type { AnalyzeOptions, ProgressReporter } from './tools/analyze-core.js';
+import type { IFrameResult } from './types.js';
+import { filterAnalysisResult } from './utils/field-filter.js';
+import { isVideoSource } from './utils/url-detector.js';
+
+const CLI_USAGE = `Usage: mcp-video-analyzer analyze <url-or-path> [options]
+
+One-shot video analysis. Prints a single JSON document to stdout (progress and
+errors go to stderr). Frame images are copied to --out and referenced by
+absolute path in the JSON. Partial failures degrade into the "warnings" array
+(exit 0); only a hard failure exits 1.
+
+Options:
+  --detail <level>        brief | standard | detailed (default: standard)
+  --max-frames <n>        Max key frames to extract (1-60; default adapts to duration)
+  --fields <list>         Comma-separated subset of: metadata,transcript,frames,
+                          comments,chapters,ocrResults,timeline,aiSummary
+  --force-refresh         Bypass cache and re-analyze
+  --ocr-language <codes>  Tesseract OCR languages (default: eng+por)
+  --model <name>          Whisper model override (e.g. small, medium)
+  --language <code>       Forced transcription language (e.g. pt)
+  --out <dir>             Where to copy frame images
+                          (default: <tmp>/mcp-video-analyzer/<url-hash>)
+  -h, --help              Show this help
+
+Sources: Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch,
+Dailymotion, Facebook (yt-dlp required), direct .mp4/.webm/.mov URLs, and
+absolute local paths / file:// URIs.
+`;
+
+export interface CliInvocation {
+  url: string | undefined;
+  options: AnalyzeOptions;
+  outDir: string | undefined;
+  help: boolean;
+}
+
+/** Parse `analyze` argv. Throws on unknown flags (parseArgs) or invalid option values (zod). */
+export function parseCliArgs(argv: string[]): CliInvocation {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      detail: { type: 'string' },
+      'max-frames': { type: 'string' },
+      fields: { type: 'string' },
+      'force-refresh': { type: 'boolean' },
+      'ocr-language': { type: 'string' },
+      model: { type: 'string' },
+      language: { type: 'string' },
+      out: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+  });
+
+  const raw: Record<string, unknown> = {};
+  if (values.detail !== undefined) raw.detail = values.detail;
+  if (values['max-frames'] !== undefined) raw.maxFrames = Number(values['max-frames']);
+  if (values.fields !== undefined) {
+    raw.fields = values.fields
+      .split(',')
+      .map((f) => f.trim())
+      .filter(Boolean);
+  }
+  if (values['force-refresh']) raw.forceRefresh = true;
+  if (values['ocr-language'] !== undefined) raw.ocrLanguage = values['ocr-language'];
+  if (values.model !== undefined) raw.model = values.model;
+  if (values.language !== undefined) raw.language = values.language;
+
+  // Validation (enum/range) comes from the shared MCP tool schema.
+  const options = AnalyzeOptionsSchema.parse(Object.keys(raw).length > 0 ? raw : undefined);
+
+  return {
+    url: positionals[0],
+    options,
+    outDir: values.out,
+    help: values.help ?? false,
+  };
+}
+
+/** Stable per-source frames dir so repeat runs reuse the same folder. */
+export function defaultOutDir(url: string): string {
+  const hash = createHash('sha256').update(url).digest('hex').slice(0, 12);
+  return join(tmpdir(), 'mcp-video-analyzer', hash);
+}
+
+/**
+ * Copy frame images out of the per-call temp dir (about to be cleaned up) into
+ * `outDir`, rewriting each `filePath`. Keeps the temp basenames — never derive
+ * names from `time` values, which contain `:` (illegal on Windows). A frame
+ * whose source file is already gone is dropped and counted in `missing`.
+ */
+export async function copyFrames(
+  frames: IFrameResult[],
+  outDir: string,
+): Promise<{ frames: IFrameResult[]; missing: number }> {
+  await mkdir(outDir, { recursive: true });
+  const copied: IFrameResult[] = [];
+  let missing = 0;
+  for (const frame of frames) {
+    const dest = join(outDir, basename(frame.filePath));
+    try {
+      await copyFile(frame.filePath, dest);
+      copied.push({ ...frame, filePath: dest });
+    } catch {
+      missing++;
+    }
+  }
+  return { frames: copied, missing };
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof ZodError) {
+    return err.issues
+      .map((issue) => `Invalid option "${String(issue.path[0] ?? '')}": ${issue.message}`)
+      .join('\n');
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * `mcp-video-analyzer analyze` entry point. stdout is reserved for the single
+ * JSON result document — everything else (progress, errors) goes to stderr.
+ */
+export async function runCli(argv: string[]): Promise<number> {
+  let invocation: CliInvocation;
+  try {
+    invocation = parseCliArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${formatError(err)}\n\n${CLI_USAGE}`);
+    return 1;
+  }
+
+  if (invocation.help) {
+    process.stdout.write(CLI_USAGE);
+    return 0;
+  }
+
+  const { url } = invocation;
+  if (!url || !isVideoSource(url)) {
+    process.stderr.write(
+      'Must be a supported video URL (Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch, Dailymotion, Facebook), a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file\n',
+    );
+    return 1;
+  }
+
+  registerAllAdapters();
+
+  const progress: ProgressReporter = async (percent, message) => {
+    process.stderr.write(`[${Math.round(percent)}%] ${message ?? ''}\n`);
+  };
+
+  let handle;
+  try {
+    handle = await getAnalysis(url, resolveAnalyzeParams(invocation.options), progress);
+  } catch (err) {
+    process.stderr.write(`${formatError(err)}\n`);
+    return 1;
+  }
+
+  const { result } = handle;
+  const fields = invocation.options?.fields;
+  const wantFrames = !fields || fields.includes('frames');
+
+  let frames: IFrameResult[] = [];
+  let missing = 0;
+  if (wantFrames && result.frames.length > 0) {
+    ({ frames, missing } = await copyFrames(
+      result.frames,
+      invocation.outDir ?? defaultOutDir(url),
+    ));
+  }
+  await handle.cleanup();
+
+  const filtered = filterAnalysisResult(result, fields);
+  const warnings =
+    missing > 0
+      ? [
+          ...filtered.warnings,
+          `${missing} of ${result.frames.length} frame image(s) were unavailable (likely cleaned up after caching) — re-run with --force-refresh to regenerate them.`,
+        ]
+      : filtered.warnings;
+
+  const doc: Record<string, unknown> = {
+    ...filtered,
+    warnings,
+    frameCount: result.frames.length,
+  };
+  if (wantFrames) doc.frames = frames;
+
+  process.stdout.write(`${JSON.stringify(doc, null, 2)}\n`);
+  return 0;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,14 +1,19 @@
 import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { copyFile, mkdir } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { basename, join } from 'node:path';
+import { basename, isAbsolute, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import { ZodError } from 'zod';
-import { registerAllAdapters } from './server.js';
-import { AnalyzeOptionsSchema, getAnalysis, resolveAnalyzeParams } from './tools/analyze-core.js';
+import { registerAllAdapters } from './adapters/register.js';
+import {
+  AnalyzeOptionsSchema,
+  assembleResultDoc,
+  getAnalysis,
+  resolveAnalyzeParams,
+} from './tools/analyze-core.js';
 import type { AnalyzeOptions, ProgressReporter } from './tools/analyze-core.js';
 import type { IFrameResult } from './types.js';
-import { filterAnalysisResult } from './utils/field-filter.js';
+import { persistentCacheDir } from './utils/temp-files.js';
 import { isVideoSource } from './utils/url-detector.js';
 
 const CLI_USAGE = `Usage: mcp-video-analyzer analyze <url-or-path> [options]
@@ -21,8 +26,10 @@ absolute path in the JSON. Partial failures degrade into the "warnings" array
 Options:
   --detail <level>        brief | standard | detailed (default: standard)
   --max-frames <n>        Max key frames to extract (1-60; default adapts to duration)
-  --fields <list>         Comma-separated subset of: metadata,transcript,frames,
-                          comments,chapters,ocrResults,timeline,aiSummary
+  --fields <list>         Output filter — comma-separated subset of: metadata,
+                          transcript,frames,comments,chapters,ocrResults,
+                          timeline,aiSummary. Filters the emitted JSON only;
+                          use --detail brief to actually skip frame extraction.
   --force-refresh         Bypass cache and re-analyze
   --ocr-language <codes>  Tesseract OCR languages (default: eng+por)
   --model <name>          Whisper model override (e.g. small, medium)
@@ -33,7 +40,7 @@ Options:
 
 Sources: Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch,
 Dailymotion, Facebook (yt-dlp required), direct .mp4/.webm/.mov URLs, and
-absolute local paths / file:// URIs.
+local paths / file:// URIs.
 `;
 
 export interface CliInvocation {
@@ -89,32 +96,43 @@ export function parseCliArgs(argv: string[]): CliInvocation {
 /** Stable per-source frames dir so repeat runs reuse the same folder. */
 export function defaultOutDir(url: string): string {
   const hash = createHash('sha256').update(url).digest('hex').slice(0, 12);
-  return join(tmpdir(), 'mcp-video-analyzer', hash);
+  return persistentCacheDir(hash);
 }
 
 /**
  * Copy frame images out of the per-call temp dir (about to be cleaned up) into
  * `outDir`, rewriting each `filePath`. Keeps the temp basenames — never derive
- * names from `time` values, which contain `:` (illegal on Windows). A frame
- * whose source file is already gone is dropped and counted in `missing`.
+ * names from `time` values, which contain `:` (illegal on Windows).
+ *
+ * ENOENT on the source (frame already cleaned up after a cache hit) is the
+ * benign case, counted in `missing`. Any other failure (EACCES/ENOSPC/EROFS on
+ * the destination) is a real write problem — reported per-frame in `errors`
+ * with the actual errno message, never disguised as a cache race.
  */
 export async function copyFrames(
   frames: IFrameResult[],
   outDir: string,
-): Promise<{ frames: IFrameResult[]; missing: number }> {
+): Promise<{ frames: IFrameResult[]; missing: number; errors: string[] }> {
   await mkdir(outDir, { recursive: true });
   const copied: IFrameResult[] = [];
   let missing = 0;
+  const errors: string[] = [];
   for (const frame of frames) {
     const dest = join(outDir, basename(frame.filePath));
     try {
       await copyFile(frame.filePath, dest);
       copied.push({ ...frame, filePath: dest });
-    } catch {
-      missing++;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        missing++;
+      } else {
+        errors.push(
+          `Frame copy to ${dest} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
-  return { frames: copied, missing };
+  return { frames: copied, missing, errors };
 }
 
 function formatError(err: unknown): string {
@@ -144,10 +162,15 @@ export async function runCli(argv: string[]): Promise<number> {
     return 0;
   }
 
-  const { url } = invocation;
+  // A CLI runs from a known shell cwd, so resolve relative local paths before
+  // the gate (the MCP server rejects them — its cwd is unpredictable).
+  let url = invocation.url;
+  if (url && !isAbsolute(url) && !url.includes('://') && existsSync(url)) {
+    url = resolve(url);
+  }
   if (!url || !isVideoSource(url)) {
     process.stderr.write(
-      'Must be a supported video URL (Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch, Dailymotion, Facebook), a direct .mp4/.webm/.mov URL, or an absolute path / file:// URI to a local video file\n',
+      'Must be a supported video URL (Loom, YouTube, Vimeo, TikTok, Instagram, X/Twitter, Twitch, Dailymotion, Facebook), a direct .mp4/.webm/.mov URL, or a path / file:// URI to a local video file\n',
     );
     return 1;
   }
@@ -172,28 +195,31 @@ export async function runCli(argv: string[]): Promise<number> {
 
   let frames: IFrameResult[] = [];
   let missing = 0;
-  if (wantFrames && result.frames.length > 0) {
-    ({ frames, missing } = await copyFrames(
-      result.frames,
-      invocation.outDir ?? defaultOutDir(url),
-    ));
+  const copyWarnings: string[] = [];
+  try {
+    if (wantFrames && result.frames.length > 0) {
+      const copied = await copyFrames(result.frames, invocation.outDir ?? defaultOutDir(url));
+      frames = copied.frames;
+      missing = copied.missing;
+      copyWarnings.push(...copied.errors);
+    }
+  } catch (err) {
+    // A failed mkdir/copy (bad --out, permissions) must not discard an
+    // analysis that already succeeded — degrade into warnings[] and emit the
+    // document without frame files (graceful-degradation convention).
+    copyWarnings.push(
+      `Frame images could not be copied to the output dir: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  } finally {
+    // Always reclaim the per-call temp dir, even when the copy failed.
+    await handle.cleanup();
   }
-  await handle.cleanup();
 
-  const filtered = filterAnalysisResult(result, fields);
-  const warnings =
-    missing > 0
-      ? [
-          ...filtered.warnings,
-          `${missing} of ${result.frames.length} frame image(s) were unavailable (likely cleaned up after caching) — re-run with --force-refresh to regenerate them.`,
-        ]
-      : filtered.warnings;
-
-  const doc: Record<string, unknown> = {
-    ...filtered,
-    warnings,
-    frameCount: result.frames.length,
-  };
+  const doc = assembleResultDoc(result, fields, {
+    missingFrames: missing,
+    refreshHint: '--force-refresh',
+    extraWarnings: copyWarnings,
+  });
   if (wantFrames) doc.frames = frames;
 
   process.stdout.write(`${JSON.stringify(doc, null, 2)}\n`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,28 @@
 #!/usr/bin/env node
 
-import { createServer } from './server.js';
+import { VERSION } from './version.js';
 
-const server = createServer();
-server.start({ transportType: 'stdio' });
+const USAGE = `mcp-video-analyzer ${VERSION}
+
+Usage:
+  mcp-video-analyzer                          Start the MCP server (stdio)
+  mcp-video-analyzer analyze <url> [options]  One-shot analysis: JSON on stdout
+  mcp-video-analyzer analyze --help           Show analyze options
+`;
+
+const cmd = process.argv[2];
+
+if (cmd === 'analyze') {
+  const { runCli } = await import('./cli.js');
+  process.exitCode = await runCli(process.argv.slice(3));
+} else if (cmd === '--version' || cmd === '-v') {
+  process.stdout.write(`${VERSION}\n`);
+} else if (cmd === '--help' || cmd === '-h') {
+  process.stdout.write(USAGE);
+} else if (cmd === undefined) {
+  const { createServer } = await import('./server.js');
+  createServer().start({ transportType: 'stdio' });
+} else {
+  process.stderr.write(`Unknown command "${cmd}".\n\n${USAGE}`);
+  process.exitCode = 1;
+}

--- a/src/processors/frame-ocr.test.ts
+++ b/src/processors/frame-ocr.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from 'vitest';
-import { isMeaningfulOcr } from './frame-ocr.js';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { isMeaningfulOcr, ocrFrames } from './frame-ocr.js';
+
+const createWorker = vi.hoisted(() =>
+  vi.fn(async () => ({
+    recognize: async () => ({ data: { text: 'mocked text', confidence: 90 } }),
+    terminate: async () => undefined,
+  })),
+);
+
+vi.mock('tesseract.js', () => ({ createWorker, default: { createWorker } }));
 
 describe('isMeaningfulOcr', () => {
   it('requires text length > 3 AND confidence > 50 (both strict)', () => {
@@ -14,5 +25,19 @@ describe('isMeaningfulOcr', () => {
     expect(isMeaningfulOcr({ time: '0:01', text: 'abcde', confidence: 51 })).toBe(true);
     // empty text → rejected
     expect(isMeaningfulOcr({ time: '0:01', text: '', confidence: 99 })).toBe(false);
+  });
+});
+
+describe('ocrFrames', () => {
+  it('routes traineddata downloads to the tmp cache dir, never the process cwd', async () => {
+    const results = await ocrFrames(
+      [{ time: '0:00', filePath: join(tmpdir(), 'nonexistent-frame.jpg'), mimeType: 'image/jpeg' }],
+      'eng',
+    );
+
+    expect(results).toHaveLength(1);
+    expect(createWorker).toHaveBeenCalledWith('eng', undefined, {
+      cachePath: join(tmpdir(), 'mcp-video-analyzer', 'tessdata'),
+    });
   });
 });

--- a/src/processors/frame-ocr.ts
+++ b/src/processors/frame-ocr.ts
@@ -1,4 +1,6 @@
-import { rm } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { IFrameResult, IOcrEntry } from '../types.js';
 import { preprocessForOcr } from './image-optimizer.js';
 
@@ -44,7 +46,13 @@ export async function ocrFrames(
   // improves OCR of stylized on-screen text. On by default; set
   // MCP_OCR_PREPROCESS=0 to OCR the raw frames instead.
   const preprocess = process.env.MCP_OCR_PREPROCESS !== '0';
-  const worker = await Tesseract.createWorker(language);
+
+  // Cache ~MB-sized .traineddata downloads in a stable temp dir — tesseract.js
+  // defaults to the process cwd, which pollutes whatever directory the
+  // server/CLI happens to run from (an agent's project root under npx).
+  const cachePath = join(tmpdir(), 'mcp-video-analyzer', 'tessdata');
+  await mkdir(cachePath, { recursive: true }).catch(() => undefined);
+  const worker = await Tesseract.createWorker(language, undefined, { cachePath });
 
   try {
     const results: IOcrResult[] = [];

--- a/src/processors/frame-ocr.ts
+++ b/src/processors/frame-ocr.ts
@@ -1,7 +1,6 @@
 import { mkdir, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import type { IFrameResult, IOcrEntry } from '../types.js';
+import { persistentCacheDir } from '../utils/temp-files.js';
 import { preprocessForOcr } from './image-optimizer.js';
 
 /**
@@ -50,8 +49,11 @@ export async function ocrFrames(
   // Cache ~MB-sized .traineddata downloads in a stable temp dir — tesseract.js
   // defaults to the process cwd, which pollutes whatever directory the
   // server/CLI happens to run from (an agent's project root under npx).
-  const cachePath = join(tmpdir(), 'mcp-video-analyzer', 'tessdata');
-  await mkdir(cachePath, { recursive: true }).catch(() => undefined);
+  // A mkdir failure propagates: both callers catch it into an "OCR failed:"
+  // warning, which beats a far-away traineddata write error (or a silent
+  // fallback to cwd — the very bug this cachePath exists to fix).
+  const cachePath = persistentCacheDir('tessdata');
+  await mkdir(cachePath, { recursive: true });
   const worker = await Tesseract.createWorker(language, undefined, { cachePath });
 
   try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,11 +13,28 @@ import { registerGetFrameBurst } from './tools/get-frame-burst.js';
 import { registerGetFrames } from './tools/get-frames.js';
 import { registerGetMetadata } from './tools/get-metadata.js';
 import { registerGetTranscript } from './tools/get-transcript.js';
+import { VERSION } from './version.js';
+
+/**
+ * Register the platform adapters (order matters: more specific first).
+ * Shared by the MCP server and the one-shot CLI (`src/cli.ts`).
+ *
+ * TwelveLabsAdapter precedes DirectAdapter: when TWELVELABS_API_KEY is set it
+ * takes over direct video URLs (Pegasus transcript + AI summary); otherwise
+ * it declines and DirectAdapter handles them as before.
+ */
+export function registerAllAdapters(): void {
+  registerAdapter(new LoomAdapter());
+  registerAdapter(new LocalFileAdapter());
+  registerAdapter(new YtDlpAdapter());
+  registerAdapter(new TwelveLabsAdapter());
+  registerAdapter(new DirectAdapter());
+}
 
 export function createServer(): FastMCP {
   const server = new FastMCP({
     name: 'mcp-video-analyzer',
-    version: '0.6.2',
+    version: VERSION,
     instructions: `Video analysis MCP server. Extracts transcripts, key frames, metadata, comments, OCR text, and annotated timelines from video URLs and local video files.
 
 AUTOMATIC BEHAVIOR — Do NOT wait for the user to ask:
@@ -62,15 +79,7 @@ Decision flow:
 6. User asks to see motion/animation → get_frame_burst`,
   });
 
-  // Register adapters (order matters: more specific first).
-  // TwelveLabsAdapter precedes DirectAdapter: when TWELVELABS_API_KEY is set it
-  // takes over direct video URLs (Pegasus transcript + AI summary); otherwise
-  // it declines and DirectAdapter handles them as before.
-  registerAdapter(new LoomAdapter());
-  registerAdapter(new LocalFileAdapter());
-  registerAdapter(new YtDlpAdapter());
-  registerAdapter(new TwelveLabsAdapter());
-  registerAdapter(new DirectAdapter());
+  registerAllAdapters();
 
   // Register tools
   registerAnalyzeVideo(server);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,10 +1,5 @@
 import { FastMCP } from 'fastmcp';
-import { registerAdapter } from './adapters/adapter.interface.js';
-import { DirectAdapter } from './adapters/direct.adapter.js';
-import { LocalFileAdapter } from './adapters/local-file.adapter.js';
-import { LoomAdapter } from './adapters/loom.adapter.js';
-import { TwelveLabsAdapter } from './adapters/twelvelabs.adapter.js';
-import { YtDlpAdapter } from './adapters/ytdlp.adapter.js';
+import { registerAllAdapters } from './adapters/register.js';
 import { registerAnalyzeMoment } from './tools/analyze-moment.js';
 import { registerAnalyzeVideo } from './tools/analyze-video.js';
 import { registerAnalyzeVideos } from './tools/analyze-videos.js';
@@ -14,22 +9,6 @@ import { registerGetFrames } from './tools/get-frames.js';
 import { registerGetMetadata } from './tools/get-metadata.js';
 import { registerGetTranscript } from './tools/get-transcript.js';
 import { VERSION } from './version.js';
-
-/**
- * Register the platform adapters (order matters: more specific first).
- * Shared by the MCP server and the one-shot CLI (`src/cli.ts`).
- *
- * TwelveLabsAdapter precedes DirectAdapter: when TWELVELABS_API_KEY is set it
- * takes over direct video URLs (Pegasus transcript + AI summary); otherwise
- * it declines and DirectAdapter handles them as before.
- */
-export function registerAllAdapters(): void {
-  registerAdapter(new LoomAdapter());
-  registerAdapter(new LocalFileAdapter());
-  registerAdapter(new YtDlpAdapter());
-  registerAdapter(new TwelveLabsAdapter());
-  registerAdapter(new DirectAdapter());
-}
 
 export function createServer(): FastMCP {
   const server = new FastMCP({

--- a/src/tools/analyze-core.ts
+++ b/src/tools/analyze-core.ts
@@ -524,6 +524,28 @@ export async function getAnalysis(
 export type ToolContent = { type: 'text'; text: string } | Awaited<ReturnType<typeof imageContent>>;
 
 /**
+ * Assemble the field-filtered result document shared by the MCP content
+ * builder and the CLI (the "CLI JSON shape" contract in CLAUDE.md): filtered
+ * fields + warnings (missing-frames hint appended when some frame images were
+ * gone) + `frameCount`. Callers attach their own frame representation on top
+ * (inline images + `framesEmbedded`, or copied `frames[].filePath` entries).
+ */
+export function assembleResultDoc(
+  result: IAnalysisResult,
+  fields: AnalysisField[] | undefined,
+  opts: { missingFrames: number; refreshHint: string; extraWarnings?: string[] },
+): Record<string, unknown> {
+  const filtered = filterAnalysisResult(result, fields);
+  const warnings = [...filtered.warnings, ...(opts.extraWarnings ?? [])];
+  if (opts.missingFrames > 0) {
+    warnings.push(
+      `${opts.missingFrames} of ${result.frames.length} frame image(s) were unavailable (likely cleaned up after caching) — re-run with ${opts.refreshHint} to regenerate them.`,
+    );
+  }
+  return { ...filtered, warnings, frameCount: result.frames.length };
+}
+
+/**
  * Build the MCP tool response content for an analysis result: a JSON text block
  * (field-filtered) followed by the frame images (unless `frames` is filtered
  * out).
@@ -550,20 +572,9 @@ export async function buildAnalysisContent(
     }
   }
 
-  const filtered = filterAnalysisResult(result, fields);
   const missing = includeFrames ? result.frames.length - images.length : 0;
-  const warnings =
-    missing > 0
-      ? [
-          ...filtered.warnings,
-          `${missing} of ${result.frames.length} frame image(s) were unavailable (likely cleaned up after caching) — re-run with forceRefresh to regenerate them.`,
-        ]
-      : filtered.warnings;
-
   const textData = {
-    ...filtered,
-    warnings,
-    frameCount: result.frames.length,
+    ...assembleResultDoc(result, fields, { missingFrames: missing, refreshHint: 'forceRefresh' }),
     ...(includeFrames ? { framesEmbedded: images.length } : {}),
   };
 

--- a/src/utils/temp-files.ts
+++ b/src/utils/temp-files.ts
@@ -22,6 +22,15 @@ export function getTempFilePath(dir: string, name: string): string {
   return join(dir, name);
 }
 
+/**
+ * Stable cross-run cache root: `<tmp>/mcp-video-analyzer/<...segments>`.
+ * Single definition for every persistent on-disk location (tessdata cache,
+ * CLI frame output) — unlike `createTempDir` dirs, these survive the process.
+ */
+export function persistentCacheDir(...segments: string[]): string {
+  return join(tmpdir(), 'mcp-video-analyzer', ...segments);
+}
+
 function cleanupAllTempDirs(): void {
   for (const dir of activeTempDirs) {
     rm(dir, { recursive: true, force: true }).catch(() => undefined);

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+import { VERSION } from './version.js';
+
+async function readJson(relative: string): Promise<{ version: string }> {
+  return JSON.parse(await readFile(new URL(relative, import.meta.url), 'utf8'));
+}
+
+describe('VERSION', () => {
+  it('matches package.json and .claude-plugin/plugin.json (release checklist)', async () => {
+    const pkg = await readJson('../package.json');
+    const plugin = await readJson('../.claude-plugin/plugin.json');
+    expect(pkg.version).toBe(VERSION);
+    expect(plugin.version).toBe(VERSION);
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Single source of truth for the runtime version string. Must match
+ * package.json (and .claude-plugin/plugin.json) — see the release checklist
+ * in CLAUDE.md. `as const` preserves the `${number}.${number}.${number}`
+ * literal type FastMCP's `version` field requires.
+ */
+export const VERSION = '0.7.0' as const;

--- a/test/smoke/cli-analyze.test.ts
+++ b/test/smoke/cli-analyze.test.ts
@@ -1,0 +1,65 @@
+import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = fileURLToPath(new URL('.', import.meta.url));
+const entryPoint = join(testDir, '..', '..', 'dist', 'index.js');
+const tinyMp4 = join(testDir, '..', 'fixtures', 'tiny.mp4');
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function run(args: string[]): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [entryPoint, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    proc.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    proc.on('error', reject);
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+describe('CLI smoke test', () => {
+  it('analyze <local file> --detail brief prints a single JSON document on stdout', async () => {
+    const { code, stdout, stderr } = await run(['analyze', tinyMp4, '--detail', 'brief']);
+
+    expect(code, `stderr: ${stderr}`).toBe(0);
+    // stdout must be nothing but the JSON document (the skill contract).
+    const doc = JSON.parse(stdout);
+    expect(doc.metadata?.title).toBe('tiny.mp4');
+    expect(Array.isArray(doc.warnings)).toBe(true);
+    expect(typeof doc.frameCount).toBe('number');
+  });
+
+  it('analyze --help exits 0 with usage on stdout', async () => {
+    const { code, stdout } = await run(['analyze', '--help']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('Usage: mcp-video-analyzer analyze');
+  });
+
+  it('analyze with an unsupported source exits 1 with stderr only', async () => {
+    const { code, stdout, stderr } = await run(['analyze', 'not-a-video']);
+    expect(code).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('supported video URL');
+  });
+
+  it('--version prints the version', async () => {
+    const { code, stdout } = await run(['--version']);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/test/smoke/cli-analyze.test.ts
+++ b/test/smoke/cli-analyze.test.ts
@@ -1,7 +1,11 @@
 import { spawn } from 'node:child_process';
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import ffmpegPath from 'ffmpeg-static';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 const testDir = fileURLToPath(new URL('.', import.meta.url));
 const entryPoint = join(testDir, '..', '..', 'dist', 'index.js');
@@ -13,9 +17,10 @@ interface RunResult {
   stderr: string;
 }
 
-function run(args: string[]): Promise<RunResult> {
+function run(args: string[], cwd?: string): Promise<RunResult> {
   return new Promise((resolve, reject) => {
     const proc = spawn('node', [entryPoint, ...args], {
+      cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, NODE_NO_WARNINGS: '1' },
     });
@@ -33,6 +38,16 @@ function run(args: string[]): Promise<RunResult> {
 }
 
 describe('CLI smoke test', () => {
+  let scratch: string;
+
+  beforeAll(async () => {
+    scratch = await mkdtemp(join(tmpdir(), 'cli-smoke-'));
+  });
+
+  afterAll(async () => {
+    await rm(scratch, { recursive: true, force: true });
+  });
+
   it('analyze <local file> --detail brief prints a single JSON document on stdout', async () => {
     const { code, stdout, stderr } = await run(['analyze', tinyMp4, '--detail', 'brief']);
 
@@ -43,6 +58,82 @@ describe('CLI smoke test', () => {
     expect(Array.isArray(doc.warnings)).toBe(true);
     expect(typeof doc.frameCount).toBe('number');
   });
+
+  it('resolves a relative path against the shell cwd', async () => {
+    const { code, stdout, stderr } = await run(
+      ['analyze', 'tiny.mp4', '--detail', 'brief'],
+      dirname(tinyMp4),
+    );
+
+    expect(code, `stderr: ${stderr}`).toBe(0);
+    expect(JSON.parse(stdout).metadata?.title).toBe('tiny.mp4');
+  });
+
+  it('--fields metadata,transcript omits frames, keeps frameCount, creates no out dir', async () => {
+    const outDir = join(scratch, 'never-created');
+    const { code, stdout } = await run([
+      'analyze',
+      tinyMp4,
+      '--fields',
+      'metadata,transcript',
+      '--out',
+      outDir,
+    ]);
+
+    expect(code).toBe(0);
+    const doc = JSON.parse(stdout);
+    expect(doc.frames).toBeUndefined();
+    expect(typeof doc.frameCount).toBe('number');
+    expect(Array.isArray(doc.transcript)).toBe(true);
+    expect(existsSync(outDir)).toBe(false);
+  });
+
+  it('copies frame files that survive process exit (copy-before-cleanup invariant)', async () => {
+    // tiny.mp4 is a black clip whose frames are filtered out, so generate a
+    // clip with real content for the frames path.
+    const clip = join(scratch, 'testsrc.mp4');
+    await new Promise<void>((resolvePromise, rejectPromise) => {
+      const proc = spawn(
+        ffmpegPath as string,
+        [
+          '-y',
+          '-f',
+          'lavfi',
+          '-i',
+          'testsrc=duration=6:size=320x240:rate=10',
+          '-pix_fmt',
+          'yuv420p',
+          clip,
+        ],
+        { stdio: 'ignore' },
+      );
+      proc.on('error', rejectPromise);
+      proc.on('close', (code) =>
+        code === 0 ? resolvePromise() : rejectPromise(new Error(`ffmpeg exited ${code}`)),
+      );
+    });
+
+    const outDir = join(scratch, 'frames-out');
+    const { code, stdout, stderr } = await run([
+      'analyze',
+      clip,
+      '--max-frames',
+      '3',
+      '--out',
+      outDir,
+    ]);
+
+    expect(code, `stderr: ${stderr}`).toBe(0);
+    const doc = JSON.parse(stdout);
+    expect(doc.frameCount).toBeGreaterThanOrEqual(1);
+    expect(doc.frames.length).toBeGreaterThanOrEqual(1);
+    for (const frame of doc.frames) {
+      expect(frame.filePath.startsWith(outDir)).toBe(true);
+      // The whole point of the CLI: paths must still exist after the
+      // subprocess (and its temp-dir cleanup) has fully exited.
+      expect(existsSync(frame.filePath)).toBe(true);
+    }
+  }, 120_000);
 
   it('analyze --help exits 0 with usage on stdout', async () => {
     const { code, stdout } = await run(['analyze', '--help']);
@@ -55,6 +146,26 @@ describe('CLI smoke test', () => {
     expect(code).toBe(1);
     expect(stdout).toBe('');
     expect(stderr).toContain('supported video URL');
+  });
+
+  it('analyze with an invalid option value exits 1 with the formatted zod error', async () => {
+    const { code, stdout, stderr } = await run(['analyze', tinyMp4, '--detail', 'wrong']);
+    expect(code).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Invalid option "detail"');
+  });
+
+  it('an unknown top-level command exits 1 with stderr only', async () => {
+    const { code, stdout, stderr } = await run(['bogus']);
+    expect(code).toBe(1);
+    expect(stdout).toBe('');
+    expect(stderr).toContain('Unknown command "bogus"');
+  });
+
+  it('top-level --help exits 0 with usage on stdout', async () => {
+    const { code, stdout } = await run(['--help']);
+    expect(code).toBe(0);
+    expect(stdout).toContain('Start the MCP server');
   });
 
   it('--version prints the version', async () => {


### PR DESCRIPTION
## What

Adds the \`/watch\`-style UX (named **\`/video\`**, modeled on [bradautomates/claude-video](https://github.com/bradautomates/claude-video)) — three entry points to the **same existing engine**, zero pipeline duplication:

1. **One-shot CLI** — \`npx mcp-video-analyzer analyze <url> [flags]\` (\`src/cli.ts\`): reuses \`getAnalysis\` (same adapters, cache, Whisper, OCR, dedup). Prints a single JSON document on stdout (\`metadata\`, \`transcript\`, \`ocrResults\`, \`timeline\`, \`warnings\`, \`frames[].filePath\`); progress on stderr; frame JPEGs copied to \`--out\` (default \`<tmp>/mcp-video-analyzer/<url-hash>/\`) before temp cleanup. Flags validate through the shared \`AnalyzeOptionsSchema\`. **No args still starts the MCP stdio server** — Docker/Smithery/existing MCP configs untouched.
2. **Agent skill** — \`skills/video/SKILL.md\`: Route A calls the MCP tools when the server is connected; Route B runs the CLI via npx (works on Codex, Cursor, Copilot, etc. through \`npx skills add guimatheus92/mcp-video-analyzer\`).
3. **Claude Code plugin** — \`.claude-plugin/plugin.json\` + \`marketplace.json\` + root \`.mcp.json\`: \`/plugin install video@mcp-video-analyzer\` auto-registers the MCP server and enables \`/video <url> [question]\`.

Bonus fix: tesseract.js was downloading ~7MB of \`.traineddata\` into the process **cwd** (the gitignored files at the repo root were the evidence); now cached in \`<tmp>/mcp-video-analyzer/tessdata\` — fixes the MCP server too.

Docs sweep: README (three entry points + CLI flag table), new AGENTS.md, CONTRIBUTING, CLAUDE.md (architecture, conventions, release checklist), npm keywords. Version bumped to 0.7.0 (\`package.json\` + \`src/version.ts\` + \`plugin.json\`).

## Verification

- \`npm run check\` green — 391 tests incl. 10 new CLI unit tests (\`src/cli.test.ts\`)
- \`npm run test:smoke\` — new \`test/smoke/cli-analyze.test.ts\` runs the built CLI against \`tiny.mp4\` offline (pure-JSON stdout contract, exit codes); server-startup smoke untouched
- \`npm run verify-package\` — 0.7.0 tarball installs and starts as consumer
- Real runs: Loom URL (42 transcript entries; actionable yt-dlp warning when absent), local testsrc clip (frames deduped, OCR'd, copied to the stable out dir and present after exit), \`--fields metadata,transcript\` creates no frame dir, invalid source exits 1 with stderr only, no \`.traineddata\` lands in cwd
- \`claude plugin validate .\` passes

## After merge

Publish 0.7.0 to npm **before** announcing the skill — Route B pins \`mcp-video-analyzer@latest\`, which doesn't have the \`analyze\` subcommand yet. Then verify \`npx skills add guimatheus92/mcp-video-analyzer --list\` and a real \`/plugin install\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)