### PR TITLE
ci: harden the workflow — timeouts, push trigger, verify-package + Windows jobs, caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,23 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  # A direct push to main previously ran NOTHING — a broken main could sit
+  # unnoticed until the next PR happened to open.
+  push:
+    branches: [main]
 
+# A force-push or rapid PR update shouldn't queue stale runs behind fresh
+# ones. Never cancel main's own runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# timeout-minutes on every job: the e2e vitest config allows 420s per test, so
+# a wedged download could otherwise burn the runner's 6-hour default.
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,6 +37,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -56,6 +70,14 @@ jobs:
         with:
           path: ~/.cache/huggingface
           key: whisper-ct2-tiny-0.5.7
+      # tesseract.js fetches eng.traineddata (~15MB) into the OS tmpdir on
+      # first OCR (frame-ocr.ts cachePath); cache it. Bump the key if the
+      # tessdata language/source ever changes. Golden clips are deliberately
+      # NOT cached — regeneration costs seconds.
+      - uses: actions/cache@v4
+        with:
+          path: /tmp/mcp-video-analyzer/tessdata
+          key: tessdata-eng-v1
       - run: npm ci
       - run: npm run build
       - run: npm run test:e2e
@@ -71,6 +93,7 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     needs: check
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -80,11 +103,48 @@ jobs:
       - run: npm ci
       - run: npm run test:smoke
 
+  # verify-all's fourth leg: pack the tarball, install it in a temp dir, boot
+  # the installed server — the only check that catches packaging breakage
+  # (files list, bin wiring) before `npm publish` does. It was local-only.
+  verify-package:
+    runs-on: ubuntu-latest
+    needs: check
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run verify-package
+
+  # Windows is a first-class dev platform here (vitest pool:'forks' is
+  # REQUIRED on Windows; golden-clips.ts carries Windows-specific drawtext
+  # path escaping) yet nothing exercised it in CI. Unit tests only — the
+  # bundled ffmpeg-static WINDOWS build has drawtext, so golden-clip
+  # generation needs no GOLDEN_FFMPEG. The e2e suite stays ubuntu-only:
+  # running it twice would double the network-flake surface and minutes for
+  # little extra signal.
+  unit-windows:
+    runs-on: windows-latest
+    needs: check
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run test
+
   # Replicates what Glama CI does on every release: build the Dockerfile from
   # a fresh clone (dist/ is gitignored — the image must compile itself) and
   # prove the container actually works. See CLAUDE.md → Publishing.
   docker-image:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Build image from clean clone

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,30 @@
+# Test fixtures — provenance & licensing
+
+Attribution for the binary fixtures in this directory. The JSON/VTT/stderr
+files are hand-written test data; `tiny.mp4`/`tiny.webm` are minimal
+content-free clips (used where content must NOT matter — see the golden-clip
+rationale in `test/helpers/golden-clips.ts`).
+
+## `fonts/JetBrainsMono-Regular.ttf`
+
+- **JetBrains Mono**, © 2020 The JetBrains Mono Project Authors
+  (<https://github.com/JetBrains/JetBrainsMono>).
+- Licensed under the SIL Open Font License 1.1 — full text in
+  [`fonts/OFL.txt`](fonts/OFL.txt).
+- Used as the fixed `fontfile=` for ffmpeg drawtext when rendering golden
+  clips, so OCR-confidence floors stay stable across dev machines and CI
+  without system font discovery.
+
+## `speech.wav`
+
+- Generated for this repo with Windows TTS (.NET `System.Speech`, voice
+  "Microsoft Zira Desktop", rate −1) at 16kHz/16-bit/mono — the exact format
+  `extractAudioTrack()` produces. Synthetic speech, not a recording of a
+  person; no third-party license applies.
+- Spoken text: **"The quick brown fox jumps over the lazy dog."** (3.63s,
+  `mean_volume: -20.6dB` — safely above the −55dB silence gate).
+- Ground truth the outcome tests assert against: `SPEECH_WORDS` in
+  `test/helpers/golden-clips.ts`.
+- To regenerate: speak the same sentence into a 16kHz/16-bit/mono WAV and
+  re-verify with a local whisper (`whisper speech.wav --model tiny`). The
+  `speechClip()` mux self-invalidates via the WAV's content hash.


### PR DESCRIPTION
**Stacked on #32** — merge that first; GitHub will retarget this PR to `main` automatically. Only the last commit (`ci: harden the workflow…`) is this PR's diff.

CI gaps surfaced during the #30 exploration, each cheap to close:

| Gap | Fix |
|---|---|
| No `timeout-minutes` anywhere; e2e allows 420s **per test** | 10–30min ceilings on every job |
| Workflow only fires on `pull_request` — a direct push to main runs nothing | `push: branches: [main]` + `concurrency` (cancel-in-progress for non-main refs) |
| `verify-package` is in `verify-all` but never ran in CI | New `verify-package` job (pack → temp-dir install → boot) |
| Windows is a first-class dev platform (`pool: 'forks'` required there; golden-clips has Windows-specific drawtext path escaping) but only ubuntu runners exist | New `unit-windows` job (unit tests only — e2e stays ubuntu-only so the network-flake surface isn't doubled; rationale in the YAML) |
| tesseract traineddata (~15MB) re-downloaded on every e2e run | `actions/cache` on `/tmp/mcp-video-analyzer/tessdata`. Golden clips deliberately **not** cached — regeneration costs seconds |
| Font/fixture attribution only lives in code comments | `test/fixtures/README.md`: JetBrains Mono (OFL 1.1 → `fonts/OFL.txt`) + `speech.wav` provenance (spoken text, voice, regeneration steps) |

No runtime change, no version bump. Validation: YAML parses clean (js-yaml); this PR's own checks exercise the new `verify-package` and `unit-windows` jobs, and the run after merge proves the `push`-to-main trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
