### PR TITLE
fix: skipFrames keys the analysis cache/sidecar (#29)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "video",
   "description": "Give your agent video input. /video analyzes a URL or local file — transcript, key frames, OCR, timeline — via the mcp-video-analyzer MCP server (auto-registered) or its CLI.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": {
     "name": "Guilherme Matheus"
   },

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ For motion, vibration, animations, or fast scrolling — burst mode captures N f
 
 ## Caching
 
-Results are cached in memory for 10 minutes. Subsequent calls with the same URL and options return instantly. Use `forceRefresh: true` to bypass the cache.
+Results are cached in memory for 10 minutes. Subsequent calls with the same URL and options return instantly. Use `forceRefresh: true` to bypass the cache. `skipFrames` is part of the cache and sidecar key, so a transcript-only analysis and a framed one of the same URL never answer for each other.
 
 ### Persistent sidecars (resumable bulk processing)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-video-analyzer",
-  "version": "0.2.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-video-analyzer",
-      "version": "0.2.5",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-video-analyzer",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "MCP server for video analysis — extracts transcripts, key frames, OCR text, and metadata from video URLs and local files. Supports Loom, YouTube and other yt-dlp platforms, direct video URLs, and local video files.",
   "author": "guimatheus92",
   "license": "MIT",

--- a/src/tools/analyze-core.test.ts
+++ b/src/tools/analyze-core.test.ts
@@ -135,10 +135,12 @@ describe('cache key covers every result-defining param', () => {
   // changed the emitted frames but hashed to the same key. The compile-time
   // sibling of this table is the ExcludedFromCacheKey guard in analyze-core.ts.
   //
-  // Base options keep skipFrames: true and the mock metadata reports
-  // duration 0, so every row stays off the real frame path (no ffmpeg, no
-  // puppeteer browser fallback) — including the skipFrames: false row, whose
-  // second call would otherwise launch a real browser against the fake URL.
+  // Base options keep skipFrames: true so rows stay on the frameless path.
+  // The skipFrames: false row does enter the frame path: ffmpeg (strategy 1)
+  // is off because mockAdapter's videoDownload capability is false, and the
+  // puppeteer browser fallback (strategy 2, gated on duration > 0) is off
+  // because the mock metadata reports duration 0 — without that, this row
+  // would launch a real browser against the fake URL.
   const variants = {
     detail: { detail: 'detailed' },
     maxFrames: { maxFrames: 7 },

--- a/src/tools/analyze-core.test.ts
+++ b/src/tools/analyze-core.test.ts
@@ -135,8 +135,10 @@ describe('cache key covers every result-defining param', () => {
   // changed the emitted frames but hashed to the same key. The compile-time
   // sibling of this table is the ExcludedFromCacheKey guard in analyze-core.ts.
   //
-  // Base options keep skipFrames: true so every row stays on the fast
-  // frameless path (no ffmpeg, no browser fallback).
+  // Base options keep skipFrames: true and the mock metadata reports
+  // duration 0, so every row stays off the real frame path (no ffmpeg, no
+  // puppeteer browser fallback) — including the skipFrames: false row, whose
+  // second call would otherwise launch a real browser against the fake URL.
   const variants = {
     detail: { detail: 'detailed' },
     maxFrames: { maxFrames: 7 },
@@ -146,12 +148,21 @@ describe('cache key covers every result-defining param', () => {
     model: { model: 'medium' },
     language: { language: 'pt' },
     initialPrompt: { initialPrompt: 'Smiles glossary' },
+    skipFrames: { skipFrames: false },
   } satisfies Record<keyof ResultDefiningParams, NonNullable<AnalyzeOptions>>;
 
   it.each(Object.entries(variants))(
     'a repeat call differing only in %s misses the cache',
     async (field, delta) => {
-      const adapter = mockAdapter();
+      const adapter = mockAdapter({
+        getMetadata: vi.fn().mockResolvedValue({
+          platform: 'loom',
+          title: 'Mock',
+          duration: 0,
+          durationFormatted: '0:00',
+          url: 'mock',
+        }),
+      });
       registerAdapter(adapter);
       const url = `https://www.loom.com/share/key-${field}`;
 

--- a/src/tools/analyze-core.ts
+++ b/src/tools/analyze-core.ts
@@ -164,6 +164,9 @@ function resultDefiningParams(params: AnalyzeParams): ResultDefiningParams {
     // not answer a later `maxWidth: 0` call, and a sidecar written under one
     // MCP_FRAME_MAX_WIDTH must not be reused after that variable changes.
     maxWidth: keyedFrameMaxWidth(params.maxWidth),
+    // `|| undefined` drops `false` from the JSON key, so every sidecar and
+    // cache entry written before this field existed (all framed) stays valid.
+    skipFrames: params.skipFrames || undefined,
     ocrLanguage: params.ocrLanguage,
     model: params.transcribe.model,
     language: params.transcribe.language,
@@ -177,12 +180,7 @@ function resultDefiningParams(params: AnalyzeParams): ResultDefiningParams {
 // Adding a param without deciding which fails `npm run typecheck` with the
 // field name in the error — instead of silently serving stale cached results,
 // which is what an unkeyed `maxWidth` did until review caught it.
-type ExcludedFromCacheKey =
-  | 'forceRefresh' // cache directive — deciding whether to READ the cache, never part of the key
-  // TODO(#29): skipFrames DOES change the result (a frameless analysis is
-  // cached under the same key as a framed one) — pre-existing sibling of the
-  // #28 maxWidth bug, excluded here until that issue lands the key change.
-  | 'skipFrames';
+type ExcludedFromCacheKey = 'forceRefresh'; // cache directive — deciding whether to READ the cache, never part of the key
 // Flattening is manual and BY NAME: `transcribe` is the only nested object
 // today. A new nested param object (e.g. `frameOptions: {...}`) must be
 // flattened here the same way, or it counts as a single leaf and its

--- a/src/tools/analyze-core.ts
+++ b/src/tools/analyze-core.ts
@@ -164,8 +164,9 @@ function resultDefiningParams(params: AnalyzeParams): ResultDefiningParams {
     // not answer a later `maxWidth: 0` call, and a sidecar written under one
     // MCP_FRAME_MAX_WIDTH must not be reused after that variable changes.
     maxWidth: keyedFrameMaxWidth(params.maxWidth),
-    // `|| undefined` drops `false` from the JSON key, so every sidecar and
-    // cache entry written before this field existed (all framed) stays valid.
+    // `|| undefined` drops `false` from the JSON key: explicit false and
+    // omitted mean the same framed result, so they must share one canonical
+    // key (and one persisted sidecar shape — pinned in cache.e2e.test.ts).
     skipFrames: params.skipFrames || undefined,
     ocrLanguage: params.ocrLanguage,
     model: params.transcribe.model,
@@ -187,11 +188,9 @@ type ExcludedFromCacheKey = 'forceRefresh'; // cache directive — deciding whet
 // sub-fields slip past the per-leaf classification below.
 type ParamLeaves = Exclude<keyof AnalyzeParams, 'transcribe'> | keyof TranscribeOptions;
 type MustBeNever<T extends never> = T;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _EveryParamClassified = MustBeNever<
   Exclude<ParamLeaves, keyof ResultDefiningParams | ExcludedFromCacheKey>
 >;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type _NoStrayKeyField = MustBeNever<Exclude<keyof ResultDefiningParams, ParamLeaves>>;
 
 export type ProgressReporter = (progress: number, message?: string) => Promise<void>;

--- a/src/utils/analysis-sidecar.test.ts
+++ b/src/utils/analysis-sidecar.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { appendFile, copyFile, rm, writeFile } from 'node:fs/promises';
+import { appendFile, copyFile, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FIXTURES_DIR, createTestImage } from '../../test/helpers/index.js';
@@ -232,10 +232,11 @@ describe('sidecar write/read', () => {
     }
   });
 
-  it('keys on skipFrames but keeps pre-#29 sidecars valid for framed reads', async () => {
-    // skipFrames: true is present in the key; false resolves to an absent key
-    // (`|| undefined` in resultDefiningParams), byte-identical to every sidecar
-    // written before the field existed — all of which hold frames.
+  it('keys on skipFrames; the canonical framed shape (no entry) answers framed reads', async () => {
+    // skipFrames: true is present in the key; false resolves to an absent
+    // entry (`|| undefined` in resultDefiningParams), so all framed calls
+    // share one canonical shape. Pre-#29 sidecars also lack the entry but are
+    // retired wholesale by SIDECAR_VERSION 2 (see the poisoned-sidecar test).
     const tempDir = await createTempDir();
     try {
       const clip = join(tempDir, 'clip.mp4');
@@ -256,6 +257,36 @@ describe('sidecar write/read', () => {
       );
       expect(await readAnalysisSidecar(clip, PARAMS)).toBeNull();
       expect(await readAnalysisSidecar(clip, { ...PARAMS, skipFrames: true })).not.toBeNull();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  it('rejects a poisoned pre-#29 (version 1) frameless sidecar on a framed read', async () => {
+    // The upgrade hazard PR #34 review caught: pre-fix code never keyed
+    // skipFrames, so a frameless run under ≤0.7.1 with MCP_WRITE_SIDECARS=1
+    // persisted frames: [] under params WITHOUT a skipFrames entry — the very
+    // shape a post-fix framed read (false → absent key) produces. Only the
+    // version gate can invalidate those retroactively; this reconstructs that
+    // exact on-disk shape (real writer output, version forced to 1) and
+    // demands a recompute instead of a zero-frame disk hit.
+    const tempDir = await createTempDir();
+    try {
+      const clip = join(tempDir, 'clip.mp4');
+      await copyFile(join(FIXTURES_DIR, 'tiny.mp4'), clip);
+      const frame = await createTestImage(tempDir, 'frame.jpg');
+      await writeAnalysisSidecars(
+        clip,
+        { ...fakeResult(frame), frames: [] },
+        PARAMS, // pre-fix frameless key: no skipFrames entry
+        { transcriptFromWhisper: true },
+      );
+      const jsonPath = join(tempDir, 'clip.analysis.json');
+      const persisted = JSON.parse(await readFile(jsonPath, 'utf8'));
+      persisted.version = 1;
+      await writeFile(jsonPath, JSON.stringify(persisted));
+
+      expect(await readAnalysisSidecar(clip, PARAMS)).toBeNull();
     } finally {
       await cleanupTempDir(tempDir);
     }

--- a/src/utils/analysis-sidecar.test.ts
+++ b/src/utils/analysis-sidecar.test.ts
@@ -232,6 +232,35 @@ describe('sidecar write/read', () => {
     }
   });
 
+  it('keys on skipFrames but keeps pre-#29 sidecars valid for framed reads', async () => {
+    // skipFrames: true is present in the key; false resolves to an absent key
+    // (`|| undefined` in resultDefiningParams), byte-identical to every sidecar
+    // written before the field existed — all of which hold frames.
+    const tempDir = await createTempDir();
+    try {
+      const clip = join(tempDir, 'clip.mp4');
+      await copyFile(join(FIXTURES_DIR, 'tiny.mp4'), clip);
+      const frame = await createTestImage(tempDir, 'frame.jpg');
+
+      // A legacy (pre-#29, framed) sidecar: key has no skipFrames entry.
+      await writeAnalysisSidecars(clip, fakeResult(frame), PARAMS, { transcriptFromWhisper: true });
+      expect(await readAnalysisSidecar(clip, { ...PARAMS, skipFrames: true })).toBeNull();
+      expect(await readAnalysisSidecar(clip, PARAMS)).not.toBeNull(); // back-compat pin
+
+      // A frameless sidecar must not answer a framed read either.
+      await writeAnalysisSidecars(
+        clip,
+        { ...fakeResult(frame), frames: [] },
+        { ...PARAMS, skipFrames: true },
+        { transcriptFromWhisper: true },
+      );
+      expect(await readAnalysisSidecar(clip, PARAMS)).toBeNull();
+      expect(await readAnalysisSidecar(clip, { ...PARAMS, skipFrames: true })).not.toBeNull();
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
   it('invalidates when the source video changes (stamp mismatch)', async () => {
     const tempDir = await createTempDir();
     try {

--- a/src/utils/analysis-sidecar.ts
+++ b/src/utils/analysis-sidecar.ts
@@ -40,6 +40,12 @@ export interface ResultDefiningParams {
    * so those stay valid instead of being invalidated for no change in output.
    */
   maxWidth?: number;
+  /**
+   * `true` = frameless analysis (issue #29). Absent = frames included, which
+   * is also what every sidecar written before this field existed holds — so
+   * those stay valid instead of being invalidated for no change in output.
+   */
+  skipFrames?: true;
   ocrLanguage: string;
   model?: string;
   language?: string;

--- a/src/utils/analysis-sidecar.ts
+++ b/src/utils/analysis-sidecar.ts
@@ -21,7 +21,11 @@ import { toLocalPath } from './url-detector.js';
  *                             so the images survive temp-dir cleanup.
  */
 
-const SIDECAR_VERSION = 1;
+// v2: skipFrames joined the params key (#29). v1 sidecars written by a
+// frameless run hold frames: [] under the SAME key shape a framed read now
+// produces (skipFrames was unkeyed), so they must be recomputed once rather
+// than silently answering framed reads with zero frames.
+const SIDECAR_VERSION = 2;
 
 /**
  * The result-defining inputs that key both the in-memory cache and the on-disk
@@ -41,9 +45,10 @@ export interface ResultDefiningParams {
    */
   maxWidth?: number;
   /**
-   * `true` = frameless analysis (issue #29). Absent = frames included, which
-   * is also what every sidecar written before this field existed holds — so
-   * those stay valid instead of being invalidated for no change in output.
+   * `true` = frameless analysis (issue #29). Absent = frames included:
+   * explicit `false` is normalized away so a framed call has one canonical
+   * key. Pre-#29 sidecars never carried this entry regardless of frame
+   * content — SIDECAR_VERSION 2 is what retires them, not this key.
    */
   skipFrames?: true;
   ocrLanguage: string;

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * in CLAUDE.md. `as const` preserves the `${number}.${number}.${number}`
  * literal type FastMCP's `version` field requires.
  */
-export const VERSION = '0.7.1' as const;
+export const VERSION = '0.8.0' as const;

--- a/test/e2e/cache.e2e.test.ts
+++ b/test/e2e/cache.e2e.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearAdapters, registerAdapter } from '../../src/adapters/adapter.interface.js';
+import { LocalFileAdapter } from '../../src/adapters/local-file.adapter.js';
+import { getAnalysis, resolveAnalyzeParams } from '../../src/tools/analyze-core.js';
 import type { IAnalysisResult } from '../../src/types.js';
 import { AnalysisCache, cacheKey } from '../../src/utils/cache.js';
 import { filterAnalysisResult } from '../../src/utils/field-filter.js';
+import { sceneCutClip } from '../helpers/index.js';
 
 function createResult(title = 'Test'): IAnalysisResult {
   return {
@@ -103,5 +107,53 @@ describe('E2E: Cache integration', () => {
     expect(cache.get('a')).toBeUndefined();
     expect(cache.get('d')?.metadata.title).toBe('D');
     expect(cache.stats().size).toBe(3);
+  });
+});
+
+describe('E2E: skipFrames keys the analysis cache (issue #29, real ffmpeg)', () => {
+  beforeAll(() => {
+    clearAdapters();
+    registerAdapter(new LocalFileAdapter());
+  });
+
+  afterAll(() => {
+    clearAdapters();
+  });
+
+  beforeEach(() => {
+    // Never persist sidecars next to the shared cached golden clip, and pin
+    // the width env so ambient config can't perturb the key under test.
+    vi.stubEnv('MCP_WRITE_SIDECARS', '');
+    vi.stubEnv('MCP_FRAME_MAX_WIDTH', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  // The issue #29 repro, pinned through the real getAnalysis pipeline: a
+  // frameless analysis cached first must not answer a later framed call for
+  // the same file. Pre-fix both hashed to one key, so the second call served
+  // the cached zero-frame result — this test's framed call asserts recovered
+  // content (empty = FAIL), per the golden-fixture convention.
+  it('a framed call after a skipFrames call re-runs the pipeline and yields frames', async () => {
+    const clip = await sceneCutClip();
+
+    const frameless = await getAnalysis(
+      clip,
+      resolveAnalyzeParams({ skipFrames: true, forceRefresh: true }),
+    );
+    try {
+      expect(frameless.result.frames).toHaveLength(0);
+    } finally {
+      await frameless.cleanup();
+    }
+
+    const framed = await getAnalysis(clip, resolveAnalyzeParams({}));
+    try {
+      expect(framed.result.frames.length).toBeGreaterThan(0);
+    } finally {
+      await framed.cleanup();
+    }
   });
 });

--- a/test/e2e/cache.e2e.test.ts
+++ b/test/e2e/cache.e2e.test.ts
@@ -1,3 +1,5 @@
+import { copyFile, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearAdapters, registerAdapter } from '../../src/adapters/adapter.interface.js';
 import { LocalFileAdapter } from '../../src/adapters/local-file.adapter.js';
@@ -5,6 +7,7 @@ import { getAnalysis, resolveAnalyzeParams } from '../../src/tools/analyze-core.
 import type { IAnalysisResult } from '../../src/types.js';
 import { AnalysisCache, cacheKey } from '../../src/utils/cache.js';
 import { filterAnalysisResult } from '../../src/utils/field-filter.js';
+import { cleanupTempDir, createTempDir } from '../../src/utils/temp-files.js';
 import { sceneCutClip } from '../helpers/index.js';
 
 function createResult(title = 'Test'): IAnalysisResult {
@@ -154,6 +157,43 @@ describe('E2E: skipFrames keys the analysis cache (issue #29, real ffmpeg)', () 
       expect(framed.result.frames.length).toBeGreaterThan(0);
     } finally {
       await framed.cleanup();
+    }
+  });
+
+  // Pins the `|| undefined` normalization in resultDefiningParams(), which no
+  // other test reaches through the real pipeline: a framed run must persist a
+  // sidecar whose params OMIT skipFrames (the canonical framed shape), and an
+  // explicit skipFrames: false call must key identically to an omitted one.
+  // Dropping `|| undefined` puts `"skipFrames":false` in the persisted params
+  // and fails the shape assertion.
+  it('persists the canonical framed shape and keys explicit skipFrames:false identically', async () => {
+    vi.stubEnv('MCP_WRITE_SIDECARS', '1');
+    const tempDir = await createTempDir('key-shape-');
+    try {
+      const clip = join(tempDir, 'clip.mp4');
+      await copyFile(await sceneCutClip(), clip);
+
+      clearAdapters();
+      const adapter = new LocalFileAdapter();
+      const getMetadata = vi.spyOn(adapter, 'getMetadata');
+      registerAdapter(adapter);
+
+      const framed = await getAnalysis(clip, resolveAnalyzeParams({ forceRefresh: true }));
+      try {
+        expect(framed.result.frames.length).toBeGreaterThan(0);
+      } finally {
+        await framed.cleanup();
+      }
+
+      const persisted = JSON.parse(await readFile(join(tempDir, 'clip.analysis.json'), 'utf8'));
+      expect(persisted.params).not.toHaveProperty('skipFrames');
+
+      // Explicit false ≡ omitted: same key, so this is served from cache.
+      const explicit = await getAnalysis(clip, resolveAnalyzeParams({ skipFrames: false }));
+      await explicit.cleanup();
+      expect(getMetadata).toHaveBeenCalledTimes(1);
+    } finally {
+      await cleanupTempDir(tempDir);
     }
   });
 });


### PR DESCRIPTION
## Bug (#29)

`skipFrames` changes the result (a frameless analysis) but was excluded from `resultDefiningParams()`, so `analyze_video(url, {skipFrames: true})` followed by `analyze_video(url)` served the cached zero-frame result — for up to 10 minutes in memory, and indefinitely with `MCP_WRITE_SIDECARS=1`. Sibling of the #28 `maxWidth` defect; the golden-corpus PR (#31) left it as a `TODO(#29)` in `ExcludedFromCacheKey`.

## Fix

- `skipFrames?: true` on `ResultDefiningParams` (`src/utils/analysis-sidecar.ts`)
- `skipFrames: params.skipFrames || undefined` in `resultDefiningParams()` — explicit `false` and omitted mean the same framed result, so they normalize to one canonical key (no `skipFrames` entry)
- `'skipFrames'` removed from `ExcludedFromCacheKey`; the `_EveryParamClassified` compile guard now enforces the classification
- **`SIDECAR_VERSION` 1 → 2** (from review): pre-fix frameless runs persisted `frames: []` under the very key shape a framed read now produces, so v1 sidecars must be recomputed once instead of silently answering framed reads with zero frames

One `keyParams` object feeds both the in-memory key and the sidecar, so a single edit point fixes both.

## Tests — each proven RED against the code it guards

- **`analyze-core.test.ts`** — new `skipFrames` row in the `cache key covers every result-defining param` `it.each` table. Pre-fix: `AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times` (cache hit = the bug). The table's mock metadata now reports `duration: 0` so the `skipFrames: false` row stays off the puppeteer browser fallback (ffmpeg is off via `videoDownload: false`). Note: the table's `satisfies` clause does NOT gate CI (tsconfig excludes `*.test.ts` from `tsc --noEmit`) — the row is added by hand.
- **`test/e2e/cache.e2e.test.ts`** — the issue's repro through the real `getAnalysis` pipeline on a golden clip (real ffmpeg): frameless call, then framed call asserting `frames.length > 0` (empty = FAIL). Pre-fix: `AssertionError: expected 0 to be greater than 0`.
- **`test/e2e/cache.e2e.test.ts`** (from review) — pins the `|| undefined` normalization through the real pipeline with `MCP_WRITE_SIDECARS=1`: a framed run must persist params **without** a `skipFrames` entry, and an explicit `skipFrames: false` call must key identically to an omitted one (adapter spy stays at 1 call). Proven RED by temporarily removing `|| undefined`: `AssertionError: expected { detail: 'standard', …(3) } to not have property "skipFrames"`.
- **`analysis-sidecar.test.ts`** — contract test: a framed-shape sidecar never answers a `skipFrames: true` read and vice-versa.
- **`analysis-sidecar.test.ts`** (from review) — the poisoned pre-#29 sidecar: reconstructs the exact pre-fix on-disk shape (real writer output, version forced to 1, `frames: []`, params without `skipFrames`) and asserts a framed read rejects it. RED pre-bump (the frameless result was served), GREEN with `SIDECAR_VERSION` 2.

## Validation (actual runs)

- `WHISPER_E2E=1 npm run verify-all` → exit 0 on both revisions; after the review follow-up: check **519/519** unit (poisoned-sidecar test included), e2e **87/87** (canonical-shape test included, `golden-transcription` via local whisper CLI), smoke **11/11**, verify-package **PASS**, zero lint warnings (two stale `eslint-disable` directives from #31 cleaned up).
- Real-input repro (1.3MB Instagram reel, `MCP_WRITE_SIDECARS=1`, single process): `skipFrames` call → 0 frames in 0.1s; framed call → **12 frames + 12 OCR results** re-extracted (pre-fix it served the cached frameless result). Fresh process: framed read served from the framed sidecar in 0.0s; `skipFrames` read recomputed instead of being served the framed sidecar.

## Review follow-up

All 6 inline findings addressed:
1. **Poisoned pre-fix frameless sidecars** (the real bug found in review): fixed via `SIDECAR_VERSION` 2 + the poisoned-sidecar regression test above. This also cures the `detail: 'brief', skipFrames: false` legacy-read variant — no pre-0.8.0 sidecar survives v2.
2. **No coverage on `|| undefined`**: the canonical-shape e2e above, RED-proven by removing it.
3. **Comment accuracy** (ffmpeg attribution in the `it.each` note; the "(all framed)" back-compat overclaim in `resultDefiningParams`, the `ResultDefiningParams` JSDoc, and the sidecar test): all reworded — the version gate, not the absent key, is what retires pre-#29 sidecars.

Upgrade cost: with `MCP_WRITE_SIDECARS=1`, every pre-0.8.0 sidecar recomputes once (acceptable for an opt-in bulk feature; `<stem>.vtt` transcripts are unversioned and still reused, so Whisper does not re-run).

## Docs / skill sweep

- README "Caching": one sentence documenting that `skipFrames` keys the cache/sidecar (mirrors the `maxWidth` precedent).
- `skills/video/SKILL.md`, `AGENTS.md`, `examples/`: **unchanged on purpose** — no MCP tool name, CLI flag, or JSON-shape change, so the SKILL.md sync rule doesn't trigger.

## Known limitation (pre-existing, out of scope)

`<stem>.analysis.json` is single-slot per video: with `MCP_WRITE_SIDECARS=1`, a frameless run now overwrites a framed sidecar (and can orphan `<stem>.frames/`). Pre-existing for `maxWidth` since #28 — single-slot design. Worth a follow-up issue if bulk users hit it.

## Release

Version bumped to **0.8.0** in `package.json`, `src/version.ts`, `.claude-plugin/plugin.json` (this is the last PR of the 0.8.0 release).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
